### PR TITLE
[#5] Feat : 카테고리별 통계 API 구현

### DIFF
--- a/src/main/java/finance_us/finance_us/domain/statistics/controller/CategoryStatisticsController.java
+++ b/src/main/java/finance_us/finance_us/domain/statistics/controller/CategoryStatisticsController.java
@@ -1,0 +1,52 @@
+package finance_us.finance_us.domain.statistics.controller;
+
+import finance_us.finance_us.domain.statistics.dto.CategoryGoalStatisticsResponse;
+import finance_us.finance_us.domain.statistics.dto.CategoryStatisticsResponse;
+import finance_us.finance_us.domain.statistics.dto.GoalStatisticsResponse;
+import finance_us.finance_us.domain.statistics.service.CategoryStatisticsService;
+import finance_us.finance_us.global.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/statistics/category")
+@RequiredArgsConstructor
+public class CategoryStatisticsController {
+    private final CategoryStatisticsService categoryStatisticsService;
+
+    @GetMapping("/")
+    public ApiResponse<CategoryStatisticsResponse> getCategoryStatistics(
+            @RequestParam Long year,
+            @RequestParam Long month,
+            @RequestParam String type)
+            //@RequestHeader("Authorization") String accessToken)
+            {
+        CategoryStatisticsResponse response = categoryStatisticsService.getCategoryStatistics(year, month, type);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @GetMapping("/goal-per-total")
+    public ApiResponse<GoalStatisticsResponse> getGoalStatistics(
+            @RequestParam Long year,
+            @RequestParam Long month,
+            @RequestParam String type)
+            //@RequestHeader("Authorization") String accessToken)
+            {
+        GoalStatisticsResponse response = categoryStatisticsService.getGoalStatistics(year, month, type);
+
+        return ApiResponse.onSuccess(response);
+    }
+
+    @GetMapping("/goal-per-category")
+    public ApiResponse<CategoryGoalStatisticsResponse> getCategoryGoalStatistics(
+            @RequestParam Long year,
+            @RequestParam Long month,
+            @RequestParam String type)
+            //@RequestHeader("Authorization") String accessToken)
+            {
+        CategoryGoalStatisticsResponse response = categoryStatisticsService.getCategoryGoalStatistics(year, month, type);
+
+        return ApiResponse.onSuccess(response);
+    }
+
+}

--- a/src/main/java/finance_us/finance_us/domain/statistics/dto/CategoryGoalStatisticsResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/statistics/dto/CategoryGoalStatisticsResponse.java
@@ -1,0 +1,24 @@
+package finance_us.finance_us.domain.statistics.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CategoryGoalStatisticsResponse {
+    private Long year;
+    private Long month;
+    private String type;
+    private List<CategoryGoalData> categories;
+
+    @Getter
+    @AllArgsConstructor
+    public static class CategoryGoalData {
+        private String mainCategory;
+        private Long totalSpent;
+        private Long goal;
+        private Integer percentage;
+    }
+}

--- a/src/main/java/finance_us/finance_us/domain/statistics/dto/CategoryStatisticsResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/statistics/dto/CategoryStatisticsResponse.java
@@ -1,0 +1,28 @@
+package finance_us.finance_us.domain.statistics.dto;
+
+import finance_us.finance_us.domain.category.entity.MainCategory;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CategoryStatisticsResponse {
+    private Long year;
+    private Long month;
+    private String type;
+    private List<CategoryData> categories;
+
+    @Getter
+    @AllArgsConstructor
+    public static class CategoryData{
+        private String mainCategory;
+        private Long totalSpent;
+        private Integer percentage;
+
+        public void setPercentage(int percentage) {
+            this.percentage = percentage;
+        }
+    }
+}

--- a/src/main/java/finance_us/finance_us/domain/statistics/dto/GoalStatisticsResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/statistics/dto/GoalStatisticsResponse.java
@@ -1,0 +1,15 @@
+package finance_us.finance_us.domain.statistics.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class GoalStatisticsResponse {
+    private Long year;
+    private Long month;
+    private String type;
+    private Long totalSpent;
+    private Long goal;
+    private Integer percentage;
+}

--- a/src/main/java/finance_us/finance_us/domain/statistics/entity/CategoryStatistics.java
+++ b/src/main/java/finance_us/finance_us/domain/statistics/entity/CategoryStatistics.java
@@ -7,8 +7,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
-
-import java.sql.Timestamp;
+import finance_us.finance_us.domain.statistics.entity.status.Type;
 
 @Entity
 @Getter
@@ -23,11 +22,14 @@ public class CategoryStatistics extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private Timestamp date;
+    private Long year;
 
-    //@Enumerated(EnumType.STRING)
-    //@Column(nullable = false)
-    //private Type type;
+    @Column(nullable = false)
+    private Long month;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Type type;
 
     @Column(nullable = false)
     private Long totalMoney;

--- a/src/main/java/finance_us/finance_us/domain/statistics/entity/PeriodStatistics.java
+++ b/src/main/java/finance_us/finance_us/domain/statistics/entity/PeriodStatistics.java
@@ -2,13 +2,11 @@ package finance_us.finance_us.domain.statistics.entity;
 
 import finance_us.finance_us.domain.common.entity.BaseEntity;
 import finance_us.finance_us.domain.user.entity.User;
-import jakarta.annotation.Nullable;
+import finance_us.finance_us.domain.statistics.entity.status.Type;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
-
-import java.sql.Timestamp;
 
 @Entity
 @Getter
@@ -23,11 +21,14 @@ public class PeriodStatistics extends BaseEntity {
     private Long id;
 
     @Column(nullable = false)
-    private Timestamp date;
+    private Long year;
 
-    //@Enumerated(EnumType.STRING)
-    //@Column(nullable = false)
-    //private Type type;
+    @Column(nullable = false)
+    private Long month;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private Type type;
 
     @Column(nullable = false)
     private Long totalMoney;

--- a/src/main/java/finance_us/finance_us/domain/statistics/entity/status/Type.java
+++ b/src/main/java/finance_us/finance_us/domain/statistics/entity/status/Type.java
@@ -1,0 +1,5 @@
+package finance_us.finance_us.domain.statistics.entity.status;
+
+public enum Type {
+    EXPENSE, INCOME
+}

--- a/src/main/java/finance_us/finance_us/domain/statistics/repository/CategoryStatisticsRepository.java
+++ b/src/main/java/finance_us/finance_us/domain/statistics/repository/CategoryStatisticsRepository.java
@@ -1,0 +1,35 @@
+package finance_us.finance_us.domain.statistics.repository;
+
+import finance_us.finance_us.domain.statistics.entity.CategoryStatistics;
+import finance_us.finance_us.domain.statistics.entity.status.Type;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CategoryStatisticsRepository extends JpaRepository<CategoryStatistics, Long> {
+    @Modifying
+    @Query("UPDATE CategoryStatistics cs " +
+            "SET cs.totalGoal = :totalGoal,  cs.updatedAt = CURRENT_TIMESTAMP  " +
+            "WHERE cs.mainCategory.id = :mainCategoryId " +
+            " AND cs.user.Id = :userId" +
+            " AND cs.year = :year" +
+            " AND cs.month = :month" +
+            " AND cs.type = :type")
+    void updateGoalWithTimeStamp(Long userId, Long mainCategoryId, Long year, Long month, String type, Long totalGoal);
+
+    @Modifying
+    @Query("UPDATE CategoryStatistics cs " +
+            "SET cs.totalGoal = :totalMoney,  cs.updatedAt = CURRENT_TIMESTAMP  " +
+            "WHERE cs.mainCategory.id = :mainCategoryId " +
+            " AND cs.user.Id = :userId" +
+            " AND cs.year = :year" +
+            " AND cs.month = :month" +
+            " AND cs.type = :type")
+    void updateTotalWithTimeStamp(Long userId, Long mainCategoryId, Long year, Long month, String type, Long totalMoney);
+
+    List<CategoryStatistics> findByYearAndMonthAndType(Long year, Long month, Type type);
+}

--- a/src/main/java/finance_us/finance_us/domain/statistics/service/CategoryStatisticsService.java
+++ b/src/main/java/finance_us/finance_us/domain/statistics/service/CategoryStatisticsService.java
@@ -1,0 +1,84 @@
+package finance_us.finance_us.domain.statistics.service;
+
+import finance_us.finance_us.domain.statistics.dto.CategoryGoalStatisticsResponse;
+import finance_us.finance_us.domain.statistics.dto.CategoryStatisticsResponse;
+import finance_us.finance_us.domain.statistics.dto.GoalStatisticsResponse;
+import finance_us.finance_us.domain.statistics.entity.CategoryStatistics;
+import finance_us.finance_us.domain.statistics.entity.status.Type;
+import finance_us.finance_us.domain.statistics.repository.CategoryStatisticsRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryStatisticsService {
+    private final CategoryStatisticsRepository categoryStatisticsRepository;
+
+    public CategoryStatisticsResponse getCategoryStatistics(Long year, Long month, String type){
+        Type statisticsType = Type.valueOf(type.toUpperCase());
+
+        List<CategoryStatistics> statistics = categoryStatisticsRepository.findByYearAndMonthAndType(year, month, statisticsType);
+
+        double totalSpent = statistics.stream().mapToDouble(CategoryStatistics::getTotalMoney).sum();
+
+        List<CategoryStatisticsResponse.CategoryData> categoryData = statistics.stream()
+                .map(stat -> new CategoryStatisticsResponse.CategoryData(
+                        stat.getMainCategory().getMainName(),
+                        stat.getTotalMoney(),
+                        (int)(((double) stat.getTotalMoney() / totalSpent) * 100)
+                ))
+                .collect(Collectors.toList());
+
+        int totalPercentage = categoryData.stream()
+                .mapToInt(CategoryStatisticsResponse.CategoryData::getPercentage)
+                .sum();
+
+        int difference = 100 - totalPercentage;
+        if (difference != 0) {
+            CategoryStatisticsResponse.CategoryData largestCategory = categoryData.stream()
+                    .max((c1, c2) -> Long.compare(c1.getTotalSpent(), c2.getTotalSpent()))
+                    .orElse(null);
+
+            if (largestCategory != null) {
+                largestCategory.setPercentage(largestCategory.getPercentage() + difference);
+            }
+        }
+
+        return new CategoryStatisticsResponse(year, month, type, categoryData);
+
+    }
+
+    public GoalStatisticsResponse getGoalStatistics(Long year, Long month, String type){
+        Type statisticsType = Type.valueOf(type.toUpperCase());
+
+        List<CategoryStatistics> statistics = categoryStatisticsRepository.findByYearAndMonthAndType(year, month, statisticsType);
+
+        double totalSpent = statistics.stream().mapToDouble(CategoryStatistics::getTotalMoney).sum();
+        double totalGoal = statistics.stream().mapToDouble(CategoryStatistics::getTotalGoal).sum();
+
+        Integer percentage = totalGoal == 0 ? 0 : (int)((totalSpent / totalGoal) * 100);
+
+        return new GoalStatisticsResponse(year, month, type, (long) totalSpent, (long) totalGoal, percentage);
+    }
+
+    public CategoryGoalStatisticsResponse getCategoryGoalStatistics(Long year, Long month, String type){
+        Type statisticsType = Type.valueOf(type.toUpperCase());
+
+        List<CategoryStatistics> statistics = categoryStatisticsRepository.findByYearAndMonthAndType(year, month, statisticsType);
+
+        List<CategoryGoalStatisticsResponse.CategoryGoalData> categoryGoalData = statistics.stream()
+                .map(stat -> new CategoryGoalStatisticsResponse.CategoryGoalData(
+                        stat.getMainCategory().getMainName(),
+                        stat.getTotalMoney(),
+                        stat.getTotalGoal(),
+                        (int)((stat.getTotalMoney() / (double) stat.getTotalGoal()) * 100)
+                ))
+                .collect(Collectors.toList());
+
+        return new CategoryGoalStatisticsResponse(year, month, type, categoryGoalData);
+    }
+
+}


### PR DESCRIPTION
## 관련 이슈
- #5 

## 요약
- 총 지출/수익 중 카테고리별 차지하는 비율 조회 기능 구현
- 총 지출/수익 중 목표 금액 대비 실제 합산 금액 비율 조회 기능 구현
- 카테고리별 목표 금액 대비 실제 합산 금액 비율 조회 기능 구현

## 상세 내용
**[Dto]**
- CategoryStatisticsResponse : 총 지출/수익 중 카테고리별 차지하는 비율 조회에 대한 결과
- GoalStatisticsResponse :  총 지출/수익 중 목표 금액 대비 실제 합산 금액 비율 조회에 대한 결과
- CategoryGoalStatisticsResponse : 카테고리별 목표 금액 대비 실제 합산 금액 비율 조회에 대한 결과

**[Repository]**
- void updateGoalWithTimeStamp : category_statistics 테이블에서 대분류별 목표 금액 필드를 수정 시간과 함께 update(대분류 생성, 삭제 시 로직을 진행할 예정)
- void updateTotalWithTimeStamp : category_statistics 테이블에서 대분류별 실제 합산 금액 필드를 수정 시간과 함께 update(가계부 작성, 수정, 삭제 시 로직을 진행할 예정)
- List<CategoryStatistics> findByYearAndMonthAndType : 년도, 월, 유형(지출/수익)에 해당되는 카테고리별 통계 불러오기

**[Service]**
- public CategoryStatisticsResponse getCategoryStatistics : 총 지출/수익 중 카테고리별 차지하는 비율 조회 후 응답 반환 (모든 카테고리가 차지하는 비율의 합이 100이 되도록 함)
- public GoalStatisticsResponse getGoalStatistics : 총 지출/수익 중 목표 금액 대비 실제 합산 금액 비율 조회 후 응답 반환
- public CategoryGoalStatisticsResponse getCategoryGoalStatistics : 카테고리별 목표 금액 대비 실제 합산 금액 비율 조회 후 응답 반환

**[Controller]**
- public ApiResponse<CategoryStatisticsResponse> getCategoryStatistics : 총 지출/수익 중 카테고리별 차지하는 비율 조회 API 담당
- public ApiResponse<GoalStatisticsResponse> getGoalStatistics :  총 지출/수익 중 목표 금액 대비 실제 합산 금액 비율 조회 API 담당
- public ApiResponse<CategoryGoalStatisticsResponse> getCategoryGoalStatistics : 카테고리별 목표 금액 대비 실제 합산 금액 비율 조회 API 담당

## 유의사항 또는 기타
- 가계부를 작성, 수정, 삭제하는 경우와 대분류 및 소분류를 생성, 삭제하는 경우 category_statistics 테이블에 변경사항이 update 되도록 하는 로직으로 구성했습니다. (이후 가계부와 대분류 및 소분류 기능 구현되면 추가해야 할 것으로 보임)
- 스웨거를 통해 category_statistics 테이블이 잘 채워져 있으면 정확한 응답을 반환하는 것을 확인했습니다.