### PR TITLE
[#6] Feat : 가계부 API 구현 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+y.env

--- a/.gitignore
+++ b/.gitignore
@@ -35,5 +35,3 @@ out/
 
 ### VS Code ###
 .vscode/
-
-y.env

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
 
     implementation 'io.jsonwebtoken:jjwt:0.9.1'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+    // implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'org.springframework.boot:spring-boot-starter-mail'
 

--- a/src/main/java/finance_us/finance_us/domain/account/controller/AccountController.java
+++ b/src/main/java/finance_us/finance_us/domain/account/controller/AccountController.java
@@ -7,10 +7,7 @@ import finance_us.finance_us.domain.account.entity.Account;
 import finance_us.finance_us.domain.account.service.AccountService;
 import finance_us.finance_us.global.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
 @RestController
@@ -19,12 +16,19 @@ import org.springframework.web.bind.annotation.RestController;
 public class AccountController {
 
     private final AccountService accountService;
+
+    // 가계부 생성
     @PostMapping
     public ApiResponse<AccountResponse.AccountResponseDTO> createAccount(@RequestBody AccountRequest.AccountRequestDTO request){
-
         Account account = accountService.createAccount(request);
         return ApiResponse.onSuccess(AccountConverter.toAccountResponseDTO(account));
+    }
 
+    // 가계부 수정
+    @PatchMapping("/{accountId}")
+    public ApiResponse<AccountResponse.AccountResponseDTO> updateAccount(@PathVariable Long accountId, @RequestBody AccountRequest.AccountRequestDTO request){
+        Account account = accountService.updateAccount(accountId, request);
+        return ApiResponse.onSuccess(AccountConverter.toAccountResponseDTO(account));
     }
 
 }

--- a/src/main/java/finance_us/finance_us/domain/account/controller/AccountController.java
+++ b/src/main/java/finance_us/finance_us/domain/account/controller/AccountController.java
@@ -31,4 +31,11 @@ public class AccountController {
         return ApiResponse.onSuccess(AccountConverter.toAccountResponseDTO(account));
     }
 
+    // 가계부 삭제
+    @DeleteMapping("/{accountId}")
+    public ApiResponse<Boolean> deleteAccount(@PathVariable Long accountId){
+        accountService.deleteAccount(accountId);
+        return ApiResponse.onSuccess(true);
+    }
+
 }

--- a/src/main/java/finance_us/finance_us/domain/account/controller/AccountController.java
+++ b/src/main/java/finance_us/finance_us/domain/account/controller/AccountController.java
@@ -1,0 +1,30 @@
+package finance_us.finance_us.domain.account.controller;
+
+import finance_us.finance_us.domain.account.converter.AccountConverter;
+import finance_us.finance_us.domain.account.dto.AccountRequest;
+import finance_us.finance_us.domain.account.dto.AccountResponse;
+import finance_us.finance_us.domain.account.entity.Account;
+import finance_us.finance_us.domain.account.service.AccountService;
+import finance_us.finance_us.global.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequestMapping("/account")
+@RequiredArgsConstructor
+public class AccountController {
+
+    private final AccountService accountService;
+    @PostMapping
+    public ApiResponse<AccountResponse.AccountResponseDTO> createAccount(@RequestBody AccountRequest.AccountRequestDTO request){
+
+        Account account = accountService.createAccount(request);
+        return ApiResponse.onSuccess(AccountConverter.toAccountResponseDTO(account));
+
+    }
+
+}

--- a/src/main/java/finance_us/finance_us/domain/account/converter/AccountConverter.java
+++ b/src/main/java/finance_us/finance_us/domain/account/converter/AccountConverter.java
@@ -1,0 +1,13 @@
+package finance_us.finance_us.domain.account.converter;
+
+import finance_us.finance_us.domain.account.dto.AccountResponse;
+import finance_us.finance_us.domain.account.entity.Account;
+
+public class AccountConverter {
+
+    public static AccountResponse.AccountResponseDTO toAccountResponseDTO(Account account){
+        return AccountResponse.AccountResponseDTO.builder()
+                .accountId(account.getId())
+                .build();
+    }
+}

--- a/src/main/java/finance_us/finance_us/domain/account/dto/AccountRequest.java
+++ b/src/main/java/finance_us/finance_us/domain/account/dto/AccountRequest.java
@@ -1,0 +1,29 @@
+package finance_us.finance_us.domain.account.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+public class AccountRequest {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class AccountRequestDTO{
+        private String accountType;  // expense, income
+        private LocalDate date;
+        private String subName;
+        private String subAssetName;
+        private Long amount;
+        private String title;
+        private Boolean status;
+        private Integer score;
+        private String imageUrl;
+        private String content;
+    }
+
+}

--- a/src/main/java/finance_us/finance_us/domain/account/dto/AccountResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/account/dto/AccountResponse.java
@@ -1,0 +1,14 @@
+package finance_us.finance_us.domain.account.dto;
+
+import lombok.*;
+
+public class AccountResponse {
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class AccountResponseDTO{
+        private Long accountId;
+    }
+}

--- a/src/main/java/finance_us/finance_us/domain/account/entity/Account.java
+++ b/src/main/java/finance_us/finance_us/domain/account/entity/Account.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
 
 @Entity
 @Getter
+@Setter
 @DynamicUpdate
 @DynamicInsert
 @Builder

--- a/src/main/java/finance_us/finance_us/domain/account/entity/Account.java
+++ b/src/main/java/finance_us/finance_us/domain/account/entity/Account.java
@@ -1,14 +1,15 @@
 package finance_us.finance_us.domain.account.entity;
 
+import finance_us.finance_us.domain.account.entity.status.AccountType;
 import finance_us.finance_us.domain.category.entity.SubAsset;
 import finance_us.finance_us.domain.category.entity.SubCategory;
-import finance_us.finance_us.domain.common.entity.BaseEntity;
 import finance_us.finance_us.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
-import org.w3c.dom.Text;
+
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -17,14 +18,16 @@ import org.w3c.dom.Text;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Account extends BaseEntity {
+public class Account {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    //@Enumerated(EnumType.STRING)
-    //@Column(nullable = false)
-    //private AccountType accountType;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private AccountType accountType;
+
+    private LocalDate date;
 
     @Column(nullable = false)
     private Long amount;
@@ -35,16 +38,17 @@ public class Account extends BaseEntity {
     @Column(nullable = false)
     private Boolean status;
 
-    private String content;
-
     @Column(nullable = false)
     private int score;
+
+    private String content;
 
     private int totalLike;
 
     private int totalCheer;
 
     private String imageUrl;
+
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/finance_us/finance_us/domain/account/entity/status/AccountType.java
+++ b/src/main/java/finance_us/finance_us/domain/account/entity/status/AccountType.java
@@ -1,0 +1,6 @@
+package finance_us.finance_us.domain.account.entity.status;
+
+public enum AccountType {
+    expense,    // 지출
+    income // 수익
+}

--- a/src/main/java/finance_us/finance_us/domain/account/repository/AccountRepository.java
+++ b/src/main/java/finance_us/finance_us/domain/account/repository/AccountRepository.java
@@ -1,0 +1,9 @@
+package finance_us.finance_us.domain.account.repository;
+
+import finance_us.finance_us.domain.account.entity.Account;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface AccountRepository extends JpaRepository<Account, Long> {
+}

--- a/src/main/java/finance_us/finance_us/domain/account/service/AccountService.java
+++ b/src/main/java/finance_us/finance_us/domain/account/service/AccountService.java
@@ -1,0 +1,54 @@
+package finance_us.finance_us.domain.account.service;
+
+import finance_us.finance_us.domain.account.dto.AccountRequest;
+import finance_us.finance_us.domain.account.entity.Account;
+import finance_us.finance_us.domain.account.entity.status.AccountType;
+import finance_us.finance_us.domain.account.repository.AccountRepository;
+import finance_us.finance_us.domain.category.entity.SubAsset;
+import finance_us.finance_us.domain.category.entity.SubCategory;
+import finance_us.finance_us.domain.category.repository.SubAssetRepository;
+import finance_us.finance_us.domain.category.repository.SubCategoryRepository;
+import finance_us.finance_us.domain.user.entity.User;
+import finance_us.finance_us.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class AccountService {
+    private final AccountRepository accountRepository;
+    private final UserRepository userRepository;
+    private final SubCategoryRepository subCategoryRepository;
+    private final SubAssetRepository subAssetRepository;
+
+    public Account createAccount(AccountRequest.AccountRequestDTO request) {
+
+        // 임의로 1번 사용자 조회 (수정 필요)
+        User user = userRepository.findById(1L);
+
+        // SubCategory 조회
+        SubCategory subCategory = subCategoryRepository.findBySubName(request.getSubName())
+                .orElseThrow(() -> new IllegalArgumentException("SubCategory not found"));
+
+        // SubCategory 조회
+        SubAsset subAsset = subAssetRepository.findBySubName(request.getSubAssetName())
+                .orElseThrow(() -> new IllegalArgumentException("SubAsset not found"));
+
+        // account 생성
+        Account account = Account.builder()
+                .accountType(AccountType.valueOf(request.getAccountType()))
+                .date(request.getDate())
+                .amount(request.getAmount())
+                .title(request.getTitle())
+                .status(request.getStatus())
+                .score(request.getScore())
+                .content(request.getContent())
+                .imageUrl(request.getImageUrl())
+                .subCategory(subCategory)
+                .subAsset(subAsset)
+                .user(user)
+                .build();
+
+        return accountRepository.save(account);
+    }
+}

--- a/src/main/java/finance_us/finance_us/domain/account/service/AccountService.java
+++ b/src/main/java/finance_us/finance_us/domain/account/service/AccountService.java
@@ -81,7 +81,14 @@ public class AccountService {
         account.setSubCategory(subCategory);
         account.setSubAsset(subAsset);
 
-        // 저장 및 반환
         return accountRepository.save(account);
+    }
+
+    // 가계부 삭제
+    public void deleteAccount(Long accountId) {
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("Account not found"));
+
+        accountRepository.delete(account);
     }
 }

--- a/src/main/java/finance_us/finance_us/domain/account/service/AccountService.java
+++ b/src/main/java/finance_us/finance_us/domain/account/service/AccountService.java
@@ -21,6 +21,7 @@ public class AccountService {
     private final SubCategoryRepository subCategoryRepository;
     private final SubAssetRepository subAssetRepository;
 
+    // 가계부 생성
     public Account createAccount(AccountRequest.AccountRequestDTO request) {
 
         // 임의로 1번 사용자 조회 (수정 필요)
@@ -49,6 +50,38 @@ public class AccountService {
                 .user(user)
                 .build();
 
+        return accountRepository.save(account);
+    }
+
+
+    // 가계부 수정
+    public Account updateAccount(Long accountId, AccountRequest.AccountRequestDTO request) {
+
+        // 기존 계좌 조회
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new IllegalArgumentException("Account not found"));
+
+        // SubCategory 조회
+        SubCategory subCategory = subCategoryRepository.findBySubName(request.getSubName())
+                .orElseThrow(() -> new IllegalArgumentException("SubCategory not found"));
+
+        // SubAsset 조회
+        SubAsset subAsset = subAssetRepository.findBySubName(request.getSubAssetName())
+                .orElseThrow(() -> new IllegalArgumentException("SubAsset not found"));
+
+        // 필드 업데이트
+        account.setAccountType(AccountType.valueOf(request.getAccountType()));
+        account.setDate(request.getDate());
+        account.setAmount(request.getAmount());
+        account.setTitle(request.getTitle());
+        account.setStatus(request.getStatus());
+        account.setScore(request.getScore());
+        account.setContent(request.getContent());
+        account.setImageUrl(request.getImageUrl());
+        account.setSubCategory(subCategory);
+        account.setSubAsset(subAsset);
+
+        // 저장 및 반환
         return accountRepository.save(account);
     }
 }

--- a/src/main/java/finance_us/finance_us/domain/category/repository/SubAssetRepository.java
+++ b/src/main/java/finance_us/finance_us/domain/category/repository/SubAssetRepository.java
@@ -1,0 +1,13 @@
+package finance_us.finance_us.domain.category.repository;
+
+import finance_us.finance_us.domain.category.entity.SubAsset;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SubAssetRepository  extends JpaRepository<SubAsset, Long> {
+    // subName으로 SubAsset 조회
+    Optional<SubAsset> findBySubName(String subName);
+}

--- a/src/main/java/finance_us/finance_us/domain/category/repository/SubCategoryRepository.java
+++ b/src/main/java/finance_us/finance_us/domain/category/repository/SubCategoryRepository.java
@@ -1,0 +1,13 @@
+package finance_us.finance_us.domain.category.repository;
+
+import finance_us.finance_us.domain.category.entity.SubCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface SubCategoryRepository extends JpaRepository<SubCategory, Long> {
+    // subName으로 SubCategory 조회
+    Optional<SubCategory> findBySubName(String subName);
+}

--- a/src/main/java/finance_us/finance_us/global/config/WebSecurityConfig.java
+++ b/src/main/java/finance_us/finance_us/global/config/WebSecurityConfig.java
@@ -1,112 +1,112 @@
-package finance_us.finance_us.global.config;
-
-
-import com.fasterxml.jackson.databind.ObjectMapper;
-import finance_us.finance_us.security.JwtAuthenticationFilter;
-import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.http.MediaType;
-import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.filter.CorsFilter;
-
-import java.util.HashMap;
-import java.util.Map;
-
-@Configuration
-@EnableMethodSecurity
-@EnableWebSecurity
-public class WebSecurityConfig {
-
-    private final ObjectMapper objectMapper;
-
-    @Autowired
-    public WebSecurityConfig(ObjectMapper objectMapper) {
-        this.objectMapper = objectMapper;
-    }
-
-    @Autowired
-    private JwtAuthenticationFilter jwtAuthenticationFilter;
-
-    @Bean
-    public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
-        http.csrf(AbstractHttpConfigurer::disable);
-        http.cors(cors -> cors.configurationSource(corsConfigurationSource()));
-        http.httpBasic(basic -> basic.disable());
-        http.headers(headers -> headers.frameOptions(frame -> frame.disable()).disable());
-        http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
-        http.authorizeHttpRequests(auth -> {
-            try {
-                auth
-                        .requestMatchers(
-                                new AntPathRequestMatcher("/"),
-                                new AntPathRequestMatcher("/auth/**"),
-                                new AntPathRequestMatcher("/api/**"),
-                                new AntPathRequestMatcher("/ws-stomp/**"),
-                                new AntPathRequestMatcher("/**/*.html"),
-                                new AntPathRequestMatcher("/**/*.css"),
-                                new AntPathRequestMatcher("/**/*.js"),
-                                new AntPathRequestMatcher("/swagger-ui/**"),  // Swagger UI 경로
-                                new AntPathRequestMatcher("/v3/api-docs/**"))  // OpenAPI 경로
-                        .permitAll();
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-        });
-
-        http.exceptionHandling(except -> {
-            except.authenticationEntryPoint((request, response, e) -> {
-                Map<String, Object> data = new HashMap<>();
-                data.put("status", HttpServletResponse.SC_FORBIDDEN);
-                data.put("message", e.getMessage());
-
-                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
-                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
-
-                objectMapper.writeValue(response.getOutputStream(), data);
-            });
-        });
-
-        http.addFilterBefore(jwtAuthenticationFilter,
-                UsernamePasswordAuthenticationFilter.class);
-        http.addFilterBefore(jwtAuthenticationFilter,
-                UsernamePasswordAuthenticationFilter.class);
-        http.addFilterAfter(jwtAuthenticationFilter, CorsFilter.class);
-
-        http.authorizeHttpRequests(request -> request.anyRequest().authenticated());
-
-        return http.build();
-    }
-
-    @Bean
-    public CorsConfigurationSource corsConfigurationSource() {
-        final long MAX_AGE_SECS = 3600;
-        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-        CorsConfiguration config = new CorsConfiguration();
-        config.setAllowCredentials(true);
-        // "*" 대신에 실제 허용할 도메인을 명시적으로 지정합니다.
-        //config.addAllowedOrigin("*");
-        config.addAllowedHeader("*");
-        config.addAllowedMethod("GET");
-        config.addAllowedMethod("POST");
-        config.addAllowedMethod("PUT");
-        config.addAllowedMethod("DELETE");
-        config.addAllowedMethod("OPTIONS");
-        config.setMaxAge(MAX_AGE_SECS);
-        config.addAllowedOrigin("http://localhost:8080");
-        config.addAllowedOrigin("ws://localhost:8080");
-        source.registerCorsConfiguration("/**", config);
-        return source;
-    }
-}
+//package finance_us.finance_us.global.config;
+//
+//
+//import com.fasterxml.jackson.databind.ObjectMapper;
+//import finance_us.finance_us.security.JwtAuthenticationFilter;
+//import jakarta.servlet.http.HttpServletResponse;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.context.annotation.Bean;
+//import org.springframework.context.annotation.Configuration;
+//import org.springframework.http.MediaType;
+//import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+//import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+//import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+//import org.springframework.security.config.http.SessionCreationPolicy;
+//import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+//import org.springframework.security.web.SecurityFilterChain;
+//import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+//import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+//import org.springframework.web.cors.CorsConfiguration;
+//import org.springframework.web.cors.CorsConfigurationSource;
+//import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+//import org.springframework.web.filter.CorsFilter;
+//
+//import java.util.HashMap;
+//import java.util.Map;
+//
+//@Configuration
+//@EnableMethodSecurity
+//@EnableWebSecurity
+//public class WebSecurityConfig {
+//
+//    private final ObjectMapper objectMapper;
+//
+//    @Autowired
+//    public WebSecurityConfig(ObjectMapper objectMapper) {
+//        this.objectMapper = objectMapper;
+//    }
+//
+//    @Autowired
+//    private JwtAuthenticationFilter jwtAuthenticationFilter;
+//
+//    @Bean
+//    public SecurityFilterChain defaultSecurityFilterChain(HttpSecurity http) throws Exception {
+//        http.csrf(AbstractHttpConfigurer::disable);
+//        http.cors(cors -> cors.configurationSource(corsConfigurationSource()));
+//        http.httpBasic(basic -> basic.disable());
+//        http.headers(headers -> headers.frameOptions(frame -> frame.disable()).disable());
+//        http.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+//        http.authorizeHttpRequests(auth -> {
+//            try {
+//                auth
+//                        .requestMatchers(
+//                                new AntPathRequestMatcher("/"),
+//                                new AntPathRequestMatcher("/auth/**"),
+//                                new AntPathRequestMatcher("/api/**"),
+//                                new AntPathRequestMatcher("/ws-stomp/**"),
+//                                new AntPathRequestMatcher("/**/*.html"),
+//                                new AntPathRequestMatcher("/**/*.css"),
+//                                new AntPathRequestMatcher("/**/*.js"),
+//                                new AntPathRequestMatcher("/swagger-ui/**"),  // Swagger UI 경로
+//                                new AntPathRequestMatcher("/v3/api-docs/**"))  // OpenAPI 경로
+//                        .permitAll();
+//            } catch (Exception e) {
+//                e.printStackTrace();
+//            }
+//        });
+//
+//        http.exceptionHandling(except -> {
+//            except.authenticationEntryPoint((request, response, e) -> {
+//                Map<String, Object> data = new HashMap<>();
+//                data.put("status", HttpServletResponse.SC_FORBIDDEN);
+//                data.put("message", e.getMessage());
+//
+//                response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+//                response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+//
+//                objectMapper.writeValue(response.getOutputStream(), data);
+//            });
+//        });
+//
+//        http.addFilterBefore(jwtAuthenticationFilter,
+//                UsernamePasswordAuthenticationFilter.class);
+//        http.addFilterBefore(jwtAuthenticationFilter,
+//                UsernamePasswordAuthenticationFilter.class);
+//        http.addFilterAfter(jwtAuthenticationFilter, CorsFilter.class);
+//
+//        http.authorizeHttpRequests(request -> request.anyRequest().authenticated());
+//
+//        return http.build();
+//    }
+//
+//    @Bean
+//    public CorsConfigurationSource corsConfigurationSource() {
+//        final long MAX_AGE_SECS = 3600;
+//        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+//        CorsConfiguration config = new CorsConfiguration();
+//        config.setAllowCredentials(true);
+//        // "*" 대신에 실제 허용할 도메인을 명시적으로 지정합니다.
+//        //config.addAllowedOrigin("*");
+//        config.addAllowedHeader("*");
+//        config.addAllowedMethod("GET");
+//        config.addAllowedMethod("POST");
+//        config.addAllowedMethod("PUT");
+//        config.addAllowedMethod("DELETE");
+//        config.addAllowedMethod("OPTIONS");
+//        config.setMaxAge(MAX_AGE_SECS);
+//        config.addAllowedOrigin("http://localhost:8080");
+//        config.addAllowedOrigin("ws://localhost:8080");
+//        source.registerCorsConfiguration("/**", config);
+//        return source;
+//    }
+//}

--- a/src/main/java/finance_us/finance_us/security/JwtAuthenticationFilter.java
+++ b/src/main/java/finance_us/finance_us/security/JwtAuthenticationFilter.java
@@ -1,57 +1,57 @@
-package finance_us.finance_us.security;
-
-
-import jakarta.servlet.FilterChain;
-import jakarta.servlet.ServletException;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.security.authentication.AbstractAuthenticationToken;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.authority.AuthorityUtils;
-import org.springframework.security.core.context.SecurityContext;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
-import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
-import org.springframework.web.filter.OncePerRequestFilter;
-
-import java.io.IOException;
-
-@Slf4j
-@Component
-public class JwtAuthenticationFilter extends OncePerRequestFilter {
-    @Autowired
-    private TokenProvider tokenProvider;
-
-    @Override
-    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
-        try {
-            String token=parseBearerToken(request);
-            log.info("Filter if running...");
-
-            if(token != null && !token.equalsIgnoreCase("null")) {
-                String userId=tokenProvider.validateAndGetUserId(token);
-                log.info("Authenticated user ID :"+userId);
-                AbstractAuthenticationToken authentication=new UsernamePasswordAuthenticationToken(userId,null, AuthorityUtils.NO_AUTHORITIES);
-                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
-                SecurityContext securityContext= SecurityContextHolder.createEmptyContext();
-                securityContext.setAuthentication(authentication);
-                SecurityContextHolder.setContext(securityContext);
-            }
-        }catch (Exception e) {
-            logger.error("Failed to set user authentication in SecurityContext", e);
-        }
-        filterChain.doFilter(request, response);
-    }
-
-    private String parseBearerToken(HttpServletRequest request) {
-        String bearerToken=request.getHeader("Authorization");
-        if(StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
-            return bearerToken.substring(7);
-        }
-        return null;
-    }
-}
-
+//package finance_us.finance_us.security;
+//
+//
+//import jakarta.servlet.FilterChain;
+//import jakarta.servlet.ServletException;
+//import jakarta.servlet.http.HttpServletRequest;
+//import jakarta.servlet.http.HttpServletResponse;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.security.authentication.AbstractAuthenticationToken;
+//import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+//import org.springframework.security.core.authority.AuthorityUtils;
+//import org.springframework.security.core.context.SecurityContext;
+//import org.springframework.security.core.context.SecurityContextHolder;
+//import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+//import org.springframework.stereotype.Component;
+//import org.springframework.util.StringUtils;
+//import org.springframework.web.filter.OncePerRequestFilter;
+//
+//import java.io.IOException;
+//
+//@Slf4j
+//@Component
+//public class JwtAuthenticationFilter extends OncePerRequestFilter {
+//    @Autowired
+//    private TokenProvider tokenProvider;
+//
+//    @Override
+//    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+//        try {
+//            String token=parseBearerToken(request);
+//            log.info("Filter if running...");
+//
+//            if(token != null && !token.equalsIgnoreCase("null")) {
+//                String userId=tokenProvider.validateAndGetUserId(token);
+//                log.info("Authenticated user ID :"+userId);
+//                AbstractAuthenticationToken authentication=new UsernamePasswordAuthenticationToken(userId,null, AuthorityUtils.NO_AUTHORITIES);
+//                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+//                SecurityContext securityContext= SecurityContextHolder.createEmptyContext();
+//                securityContext.setAuthentication(authentication);
+//                SecurityContextHolder.setContext(securityContext);
+//            }
+//        }catch (Exception e) {
+//            logger.error("Failed to set user authentication in SecurityContext", e);
+//        }
+//        filterChain.doFilter(request, response);
+//    }
+//
+//    private String parseBearerToken(HttpServletRequest request) {
+//        String bearerToken=request.getHeader("Authorization");
+//        if(StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer")) {
+//            return bearerToken.substring(7);
+//        }
+//        return null;
+//    }
+//}
+//

--- a/src/main/java/finance_us/finance_us/security/TokenProvider.java
+++ b/src/main/java/finance_us/finance_us/security/TokenProvider.java
@@ -1,55 +1,55 @@
-package finance_us.finance_us.security;
-
-import finance_us.finance_us.domain.user.entity.User;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.ExpiredJwtException;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.stereotype.Service;
-
-import java.time.Instant;
-import java.time.temporal.ChronoUnit;
-import java.util.Date;
-
-@Slf4j
-@Service
-public class TokenProvider {
-    private static final String SECRET_KEY="NMA8JPctFuna59f5";
-
-    public String create(User user) {
-        Date expireDate=Date.from(
-                Instant.now()
-                        .plus(1, ChronoUnit.DAYS));
-        return Jwts.builder()
-                .signWith(SignatureAlgorithm.HS512,SECRET_KEY)
-                .setSubject(String.valueOf(user.getId()))
-                .setIssuer("todo app")
-                .setIssuedAt(new Date())
-                .setExpiration(expireDate)
-                .compact();
-    }
-
-    public String validateAndGetUserId(String token) {
-        Claims claims=Jwts.parser()
-                .setSigningKey(SECRET_KEY)
-                .parseClaimsJws(token)
-                .getBody();
-        return claims.getSubject();
-    }
-
-    public Claims validateAndGetClaims(String token) {
-        try {
-            // 토큰이 유효할 경우 Claims 반환
-            return Jwts.parser()
-                    .setSigningKey(SECRET_KEY)
-                    .parseClaimsJws(token)
-                    .getBody();
-        } catch (ExpiredJwtException e) {
-            // 토큰이 만료된 경우에도 Claims 반환 가능
-            return e.getClaims();
-        }
-    }
-
-}
-
+//package finance_us.finance_us.security;
+//
+//import finance_us.finance_us.domain.user.entity.User;
+//import io.jsonwebtoken.Claims;
+//import io.jsonwebtoken.ExpiredJwtException;
+//import io.jsonwebtoken.Jwts;
+//import io.jsonwebtoken.SignatureAlgorithm;
+//import lombok.extern.slf4j.Slf4j;
+//import org.springframework.stereotype.Service;
+//
+//import java.time.Instant;
+//import java.time.temporal.ChronoUnit;
+//import java.util.Date;
+//
+//@Slf4j
+//@Service
+//public class TokenProvider {
+//    private static final String SECRET_KEY="NMA8JPctFuna59f5";
+//
+//    public String create(User user) {
+//        Date expireDate=Date.from(
+//                Instant.now()
+//                        .plus(1, ChronoUnit.DAYS));
+//        return Jwts.builder()
+//                .signWith(SignatureAlgorithm.HS512,SECRET_KEY)
+//                .setSubject(String.valueOf(user.getId()))
+//                .setIssuer("todo app")
+//                .setIssuedAt(new Date())
+//                .setExpiration(expireDate)
+//                .compact();
+//    }
+//
+//    public String validateAndGetUserId(String token) {
+//        Claims claims=Jwts.parser()
+//                .setSigningKey(SECRET_KEY)
+//                .parseClaimsJws(token)
+//                .getBody();
+//        return claims.getSubject();
+//    }
+//
+//    public Claims validateAndGetClaims(String token) {
+//        try {
+//            // 토큰이 유효할 경우 Claims 반환
+//            return Jwts.parser()
+//                    .setSigningKey(SECRET_KEY)
+//                    .parseClaimsJws(token)
+//                    .getBody();
+//        } catch (ExpiredJwtException e) {
+//            // 토큰이 만료된 경우에도 Claims 반환 가능
+//            return e.getClaims();
+//        }
+//    }
+//
+//}
+//


### PR DESCRIPTION
## 💡 관련 이슈
- #6 

## 🎋 요약
- 가계부 생성, 수정, 삭제 기능 구현

## ⚡️ 상세 내용
- 임의의 데이터 삽입 : 카테고리와 자산에 대한 데이터를 SQL로 삽입하여 연결이 잘 되었는지 확인했습니다. 
- 사용자 데이터는 임의로 ID 1을 사용하여 확인했습니다. 

## 🔑 주요 변경사항
- 인증 관련 부분은 주석처리 하였습니다. 
