### PR TITLE
Feat/#10 사용자 계정 관리 기능 

### DIFF
--- a/src/main/java/finance_us/finance_us/domain/account/service/AccountService.java
+++ b/src/main/java/finance_us/finance_us/domain/account/service/AccountService.java
@@ -25,7 +25,7 @@ public class AccountService {
     public Account createAccount(AccountRequest.AccountRequestDTO request) {
 
         // 임의로 1번 사용자 조회 (수정 필요)
-        User user = userRepository.findById(1L);
+        User user = userRepository.findById(1L).get();
 
         // SubCategory 조회
         SubCategory subCategory = subCategoryRepository.findBySubName(request.getSubName())

--- a/src/main/java/finance_us/finance_us/domain/user/controller/UserController.java
+++ b/src/main/java/finance_us/finance_us/domain/user/controller/UserController.java
@@ -67,46 +67,8 @@ public class UserController {
         }
     }
 
-    @PatchMapping("/resetMail")
-    @Operation(summary = "이메일 변경 API", description = "이메일을 변경합니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "acess 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "acess 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
-    })
-    public ApiResponse<Boolean> resetMail(@RequestHeader("Authorization") String token, @RequestParam String email) {
 
-        Long userId = tokenProvider.extractUserIdFromToken(token);
-
-        boolean isAvailable = userService.mailCheck(email);
-
-        if (isAvailable) {
-            return ApiResponse.onSuccess(userService.changeMail(userId, email));
-        } else {
-            return ApiResponse.onFailure("COMMON400", "중복된 이메일입니다.", false);
-        }
-    }
-
-    @PatchMapping("/resetPassword")
-    @Operation(summary = "비밀번호 변경 API", description = "비밀번호를 변경합니다.")
-    @ApiResponses({
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "acess 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "acess 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
-    })
-    public ApiResponse<Boolean> resetPassword(@RequestHeader("Authorization") String token, @RequestParam String password) {
-        // 이메일 유효성 검사
-        if (password == null || password.isEmpty()) {
-            return ApiResponse.onFailure("COMMON400", "비밀번호는 공백이 될 수 없습니다.", false);
-        }
-
-        Long userId = tokenProvider.extractUserIdFromToken(token);
-
-        return ApiResponse.onSuccess(userService.changePassword(userId, password));
-    }
-
+    //회원탈퇴 Delete /api/user
 
 
 }

--- a/src/main/java/finance_us/finance_us/domain/user/controller/UserController.java
+++ b/src/main/java/finance_us/finance_us/domain/user/controller/UserController.java
@@ -2,10 +2,12 @@ package finance_us.finance_us.domain.user.controller;
 
 import finance_us.finance_us.domain.user.dto.AuthRequestDTO;
 import finance_us.finance_us.domain.user.dto.AuthResponseDTO;
+import finance_us.finance_us.domain.user.service.AuthService;
 import finance_us.finance_us.domain.user.service.UserService;
 import finance_us.finance_us.global.ApiResponse;
 import finance_us.finance_us.global.code.status.ErrorStatus;
 import finance_us.finance_us.global.exception.GeneralException;
+import finance_us.finance_us.security.TokenProvider;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -25,6 +27,12 @@ public class UserController {
     @Autowired
     private UserService userService;
 
+    @Autowired
+    private TokenProvider tokenProvider;
+
+    @Autowired
+    private AuthService authService;
+
     @GetMapping("/mailCheck")
     @Operation(summary = "이메일 중복확인 API", description = "이메일을 중복확인 합니다.")
     @ApiResponses({
@@ -32,14 +40,6 @@ public class UserController {
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
     public ApiResponse<Boolean> mailCheck(@RequestParam String email) {
-        // 이메일 유효성 검사
-        if (email == null || email.isEmpty()) {
-            throw new GeneralException(ErrorStatus.EMAIL_NOT_FOUND);
-        }
-
-        if (!userService.isValidEmail(email)) {
-            throw new GeneralException(ErrorStatus.EAMIL_VALIDATION_FAILED);
-        }
 
         boolean isAvailable = userService.mailCheck(email);
 
@@ -66,6 +66,47 @@ public class UserController {
             return ApiResponse.onFailure("COMMON400", "중복된 닉네임입니다.", false);
         }
     }
+
+    @PatchMapping("/resetMail")
+    @Operation(summary = "이메일 변경 API", description = "이메일을 변경합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "acess 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "acess 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    public ApiResponse<Boolean> resetMail(@RequestHeader("Authorization") String token, @RequestParam String email) {
+
+        Long userId = tokenProvider.extractUserIdFromToken(token);
+
+        boolean isAvailable = userService.mailCheck(email);
+
+        if (isAvailable) {
+            return ApiResponse.onSuccess(userService.changeMail(userId, email));
+        } else {
+            return ApiResponse.onFailure("COMMON400", "중복된 이메일입니다.", false);
+        }
+    }
+
+    @PatchMapping("/resetPassword")
+    @Operation(summary = "비밀번호 변경 API", description = "비밀번호를 변경합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "acess 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "acess 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    public ApiResponse<Boolean> resetPassword(@RequestHeader("Authorization") String token, @RequestParam String password) {
+        // 이메일 유효성 검사
+        if (password == null || password.isEmpty()) {
+            return ApiResponse.onFailure("COMMON400", "비밀번호는 공백이 될 수 없습니다.", false);
+        }
+
+        Long userId = tokenProvider.extractUserIdFromToken(token);
+
+        return ApiResponse.onSuccess(userService.changePassword(userId, password));
+    }
+
 
 
 }

--- a/src/main/java/finance_us/finance_us/domain/user/controller/UserController.java
+++ b/src/main/java/finance_us/finance_us/domain/user/controller/UserController.java
@@ -1,0 +1,54 @@
+package finance_us.finance_us.domain.user.controller;
+
+import finance_us.finance_us.domain.user.dto.AuthRequestDTO;
+import finance_us.finance_us.domain.user.dto.AuthResponseDTO;
+import finance_us.finance_us.domain.user.service.UserService;
+import finance_us.finance_us.global.ApiResponse;
+import finance_us.finance_us.global.code.status.ErrorStatus;
+import finance_us.finance_us.global.exception.GeneralException;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import javax.xml.stream.events.EntityReference;
+
+@RestController
+@RequestMapping("/api/user")
+@Tag(name = "User API", description = "사용자 관련 API")
+public class UserController {
+
+    @Autowired
+    private UserService userService;
+
+    @GetMapping("/mailCheck")
+    @Operation(summary = "이메일 중복확인 API", description = "이메일을 중복확인 합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    public ApiResponse<Boolean> mailCheck(@RequestParam String email) {
+        // 이메일 유효성 검사
+        if (email == null || email.isEmpty()) {
+            throw new GeneralException(ErrorStatus.EMAIL_NOT_FOUND);
+        }
+
+        if (!userService.isValidEmail(email)) {
+            throw new GeneralException(ErrorStatus.EAMIL_VALIDATION_FAILED);
+        }
+
+        boolean isAvailable = userService.mailCheck(email);
+
+        if (isAvailable) {
+            return ApiResponse.onSuccess(true);
+        } else {
+            return ApiResponse.onFailure("COMMON400", "중복된 이메일입니다.", false);
+        }
+    }
+
+
+}

--- a/src/main/java/finance_us/finance_us/domain/user/controller/UserController.java
+++ b/src/main/java/finance_us/finance_us/domain/user/controller/UserController.java
@@ -18,6 +18,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.xml.stream.events.EntityReference;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/api/user")
@@ -67,8 +69,63 @@ public class UserController {
         }
     }
 
+    @PatchMapping("/resetMail")
+    @Operation(summary = "이메일 변경 API", description = "이메일을 변경합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "acess 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "acess 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    public ApiResponse<Map<String,Object>> resetMail(@RequestHeader("Authorization") String token, @RequestParam String email) {
 
-    //회원탈퇴 Delete /api/user
+        Long userId = tokenProvider.extractUserIdFromToken(token);
 
+        userService.mailCheck(email);
+        userService.changeMail(userId, email);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("userId", userId);
+        response.put("updatedField", "email");
+
+        return ApiResponse.onSuccess(response);
+
+    }
+
+    @PatchMapping("/resetPassword")
+    @Operation(summary = "비밀번호 변경 API", description = "비밀번호를 변경합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "acess 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "acess 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    public ApiResponse<Map<String,Object>> resetPassword(@RequestHeader("Authorization") String token, @RequestParam String password) {
+
+        Long userId = tokenProvider.extractUserIdFromToken(token);
+        userService.changePassword(userId, password);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("userId", userId);
+        response.put("updatedField", "password");
+
+        return ApiResponse.onSuccess(response);
+    }
+
+    //회원탈퇴 Delete / api/user/
+    @DeleteMapping()
+    @Operation(summary = "회원 탈퇴 API", description = "회원 탈퇴합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "acess 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "acess 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    public ApiResponse<String> withDrawUser(@RequestHeader("Authorization") String token) {
+
+        Long userId = tokenProvider.extractUserIdFromToken(token);
+        userService.deleteUser(userId);
+        return ApiResponse.onSuccess("삭제 완료되었습니다. ");
+    }
 
 }

--- a/src/main/java/finance_us/finance_us/domain/user/controller/UserController.java
+++ b/src/main/java/finance_us/finance_us/domain/user/controller/UserController.java
@@ -50,5 +50,22 @@ public class UserController {
         }
     }
 
+    @GetMapping("/nameCheck")
+    @Operation(summary = "닉네임 중복확인 API", description = "닉네임을 중복확인 합니다.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "OK, 성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청입니다.", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
+    })
+    public ApiResponse<Boolean> nameCheck(@RequestParam String name) {
+
+        boolean isAvailable = userService.nameCheck(name);
+
+        if (isAvailable) {
+            return ApiResponse.onSuccess(true);
+        } else {
+            return ApiResponse.onFailure("COMMON400", "중복된 닉네임입니다.", false);
+        }
+    }
+
 
 }

--- a/src/main/java/finance_us/finance_us/domain/user/converter/AuthConverter.java
+++ b/src/main/java/finance_us/finance_us/domain/user/converter/AuthConverter.java
@@ -30,4 +30,11 @@ public class AuthConverter {
                 .build();
 
     }
+
+    public static AuthResponseDTO.UserResponseDTO toUserResponseDTO(User user){
+        return AuthResponseDTO.UserResponseDTO.builder()
+                .userId(user.getId())
+                .isAuthenticated(user.isAuthenticated())
+                .build();
+    }
 }

--- a/src/main/java/finance_us/finance_us/domain/user/dto/AuthRequestDTO.java
+++ b/src/main/java/finance_us/finance_us/domain/user/dto/AuthRequestDTO.java
@@ -14,7 +14,7 @@ public class AuthRequestDTO {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class LoginRequestDTO{
-        private String username;
+        private String email;
         private String password;
 
     }

--- a/src/main/java/finance_us/finance_us/domain/user/dto/AuthResponseDTO.java
+++ b/src/main/java/finance_us/finance_us/domain/user/dto/AuthResponseDTO.java
@@ -26,4 +26,15 @@ public class AuthResponseDTO {
         private Long id;
         private Role role;
     }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class UserResponseDTO{
+        private Long userId;
+        private boolean isAuthenticated;
+    }
+
 }

--- a/src/main/java/finance_us/finance_us/domain/user/repository/UserRepository.java
+++ b/src/main/java/finance_us/finance_us/domain/user/repository/UserRepository.java
@@ -12,7 +12,7 @@ public interface UserRepository extends JpaRepository<User,String> {
     Boolean existsByEmail(String email);
     User findByEmailAndPassword(String email, String password);
 
-    User findById(Long id);
+    Optional<User> findById(Long id);
     Optional<User> findByName(String name);
 }
 

--- a/src/main/java/finance_us/finance_us/domain/user/service/AuthService.java
+++ b/src/main/java/finance_us/finance_us/domain/user/service/AuthService.java
@@ -69,7 +69,7 @@ public class AuthService {
 
     //로그인
     public AuthResponseDTO.LoginResponseDTO login(AuthRequestDTO.LoginRequestDTO loginRequestDTO) {
-        Optional<User> optionalUser = userRepository.findByName(loginRequestDTO.getUsername());
+        Optional<User> optionalUser = userRepository.findByEmail(loginRequestDTO.getEmail());
         if (optionalUser.isEmpty()) {
             throw new GeneralException(ErrorStatus.MEMBER_NOT_FOUND);
         }

--- a/src/main/java/finance_us/finance_us/domain/user/service/AuthService.java
+++ b/src/main/java/finance_us/finance_us/domain/user/service/AuthService.java
@@ -67,7 +67,7 @@ public class AuthService {
 
     }
 
-
+    //로그인
     public AuthResponseDTO.LoginResponseDTO login(AuthRequestDTO.LoginRequestDTO loginRequestDTO) {
         Optional<User> optionalUser = userRepository.findByName(loginRequestDTO.getUsername());
         if (optionalUser.isEmpty()) {
@@ -83,6 +83,7 @@ public class AuthService {
         return new AuthResponseDTO.LoginResponseDTO(token);
     }
 
+    //토큰 재발행
     public String refreshToken(String token) {
         // 토큰에서 클레임 추출
         Claims claims = tokenProvider.extractClaims(token);
@@ -97,5 +98,16 @@ public class AuthService {
         // 새 토큰 발급
         String newToken = tokenProvider.generateToken(user.getName(), user.getId());
         return newToken;
+    }
+
+    //사용자 인증
+    public AuthResponseDTO.UserResponseDTO authUser(Long userId){
+        //사용자 확인
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        user.setAuthenticated(true);
+        userRepository.save(user);
+
+        return AuthConverter.toUserResponseDTO(user);
     }
 }

--- a/src/main/java/finance_us/finance_us/domain/user/service/AuthService.java
+++ b/src/main/java/finance_us/finance_us/domain/user/service/AuthService.java
@@ -37,7 +37,7 @@ public class AuthService {
         return AuthConverter.toSigninResponseDTO(user);
     }
 
-    private void validatePassword(String password) {
+    public void validatePassword(String password) {
         // 길이 검사
         if (password.length() < 8 || password.length() > 12) {
             throw new GeneralException(ErrorStatus.PASSWORD_VALIDATION_FAILED);
@@ -57,6 +57,14 @@ public class AuthService {
         if (count < 2) {
             throw new GeneralException(ErrorStatus.PASSWORD_VALIDATION_FAILED);
         }
+    }
+
+    // 이메일 형식 검증
+    public void isValidEmail(String email) {
+        String emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$";
+        if(!email.matches(emailRegex))
+            throw new GeneralException(ErrorStatus.EMAIL_VALIDATION_FAILED);
+
     }
 
 

--- a/src/main/java/finance_us/finance_us/domain/user/service/AuthService.java
+++ b/src/main/java/finance_us/finance_us/domain/user/service/AuthService.java
@@ -27,9 +27,6 @@ public class AuthService {
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
     public AuthResponseDTO.SignResponseDTO signUp(User user) {
-        if (userRepository.findByEmail(user.getEmail()).isPresent()) {
-            throw new GeneralException(ErrorStatus.MEMBER_NOT_FOUND);
-        }
 
         validatePassword(user.getPassword()); // 비밀번호 검증
 

--- a/src/main/java/finance_us/finance_us/domain/user/service/UserService.java
+++ b/src/main/java/finance_us/finance_us/domain/user/service/UserService.java
@@ -48,7 +48,7 @@ public class UserService {
     }
 
     //비밀번호 변경
-    public boolean changePassword(Long userId, String password){
+    public void changePassword(Long userId, String password){
         // 사용자 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
@@ -58,6 +58,12 @@ public class UserService {
         String encodedPassword = passwordEncoder.encode(password);
         user.setPassword(encodedPassword);
         userRepository.save(user);
-        return true;
+    }
+
+    //회원탈퇴
+    public void deleteUser(Long userId){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        userRepository.delete(user);
     }
 }

--- a/src/main/java/finance_us/finance_us/domain/user/service/UserService.java
+++ b/src/main/java/finance_us/finance_us/domain/user/service/UserService.java
@@ -6,6 +6,7 @@ import finance_us.finance_us.global.code.status.ErrorStatus;
 import finance_us.finance_us.global.exception.GeneralException;
 import io.jsonwebtoken.Claims;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -14,19 +15,49 @@ public class UserService {
     @Autowired
     private UserRepository userRepository;
 
+    @Autowired
+    private AuthService authService;
+
+    private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
     //이메일 중복 확인
     public boolean mailCheck(String email) {
+        authService.isValidEmail(email);
         return userRepository.findByEmail(email).isEmpty();
-    }
-
-    // 이메일 형식 검증
-    public boolean isValidEmail(String email) {
-        String emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$";
-        return email.matches(emailRegex);
     }
 
     //닉네임 중복 확인
     public boolean nameCheck(String name){
         return userRepository.findByName(name).isEmpty();
+    }
+
+    //이메일 변경
+    public boolean changeMail(Long userId, String email){
+
+        authService.isValidEmail(email);
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 이메일 변경
+        user.setEmail(email);
+
+        // 변경 사항 저장
+        userRepository.save(user);
+        return true;
+    }
+
+    //비밀번호 변경
+    public boolean changePassword(Long userId, String password){
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        authService.validatePassword(password); // 비밀번호 검증
+
+        String encodedPassword = passwordEncoder.encode(password);
+        user.setPassword(encodedPassword);
+        userRepository.save(user);
+        return true;
     }
 }

--- a/src/main/java/finance_us/finance_us/domain/user/service/UserService.java
+++ b/src/main/java/finance_us/finance_us/domain/user/service/UserService.java
@@ -24,4 +24,9 @@ public class UserService {
         String emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$";
         return email.matches(emailRegex);
     }
+
+    //닉네임 중복 확인
+    public boolean nameCheck(String name){
+        return userRepository.findByName(name).isEmpty();
+    }
 }

--- a/src/main/java/finance_us/finance_us/domain/user/service/UserService.java
+++ b/src/main/java/finance_us/finance_us/domain/user/service/UserService.java
@@ -1,0 +1,27 @@
+package finance_us.finance_us.domain.user.service;
+
+import finance_us.finance_us.domain.user.entity.User;
+import finance_us.finance_us.domain.user.repository.UserRepository;
+import finance_us.finance_us.global.code.status.ErrorStatus;
+import finance_us.finance_us.global.exception.GeneralException;
+import io.jsonwebtoken.Claims;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserService {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    //이메일 중복 확인
+    public boolean mailCheck(String email) {
+        return userRepository.findByEmail(email).isEmpty();
+    }
+
+    // 이메일 형식 검증
+    public boolean isValidEmail(String email) {
+        String emailRegex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,6}$";
+        return email.matches(emailRegex);
+    }
+}

--- a/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
+++ b/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
@@ -22,7 +22,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EMAIL_FAILED(HttpStatus.BAD_REQUEST, "MEMBER4004","이메일 전송에 실패하였습니다"),
 
     PASSWORD_VALIDATION_FAILED(HttpStatus.BAD_REQUEST,"PASSWORD4001","비밀번호는 영어 대/소문자, 숫자 중 2종류 이상을 조합해야 합니다."),
-    EAMIL_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "MEMBER4005","올바르지 않은 이메일 형식입니다."),
+    EMAIL_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "MEMBER4005","올바르지 않은 이메일 형식입니다."),
 
     JWT_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "AUTH001", "JWT 서명이 올바르지 않습니다."),
     JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH002", "JWT 토큰이 만료되었습니다."),

--- a/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
+++ b/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
@@ -20,6 +20,8 @@ public enum ErrorStatus implements BaseErrorCode {
     EMAIL_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4003", "이메일이 없습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
     EMAIL_FAILED(HttpStatus.BAD_REQUEST, "MEMBER4004","이메일 전송에 실패하였습니다"),
+    EMAIL_EXIST(HttpStatus.BAD_REQUEST,"MEMBER4005","이메일이 이미 존재합니다"),
+    NICKNAME_EXIST(HttpStatus.BAD_REQUEST,"MEMBER4006","닉네임이 이미 존재합니다"),
 
     PASSWORD_VALIDATION_FAILED(HttpStatus.BAD_REQUEST,"PASSWORD4001","비밀번호는 영어 대/소문자, 숫자 중 2종류 이상을 조합해야 합니다."),
     EMAIL_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "MEMBER4005","올바르지 않은 이메일 형식입니다."),

--- a/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
+++ b/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
@@ -22,6 +22,7 @@ public enum ErrorStatus implements BaseErrorCode {
     EMAIL_FAILED(HttpStatus.BAD_REQUEST, "MEMBER4004","이메일 전송에 실패하였습니다"),
 
     PASSWORD_VALIDATION_FAILED(HttpStatus.BAD_REQUEST,"PASSWORD4001","비밀번호는 영어 대/소문자, 숫자 중 2종류 이상을 조합해야 합니다."),
+    EAMIL_VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "MEMBER4005","올바르지 않은 이메일 형식입니다."),
 
     JWT_SIGNATURE_INVALID(HttpStatus.UNAUTHORIZED, "AUTH001", "JWT 서명이 올바르지 않습니다."),
     JWT_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH002", "JWT 토큰이 만료되었습니다."),

--- a/src/main/java/finance_us/finance_us/security/JwtAuthenticationFilter.java
+++ b/src/main/java/finance_us/finance_us/security/JwtAuthenticationFilter.java
@@ -53,5 +53,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         return null;
     }
+
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- #10 , #2 

## 🎋 요약
- 사용자 계정 관리 기능을 구현합니다. 

## ⚡️ 상세 내용
- 사용자 이메일, 닉네임 중복확인 API 구현
- 사용자 이메일, 비밀번호 변경 API 구현
- 사용자 탈퇴 기능 구현
- 사용자 인증 API 구현

## 🔑 주요 변경사항
-API 구현 외 이전에 작업했던 Auth 관련 코드를 다음과 같이 수정했습니다. 
1. 로그인 시에 이메일을 사용하여 로그인 하도록 수정
2. 사용자 인증의 경우 /api/auth 에서 작업하도록 구현 
3. 이메일 검증과 비밀번호 검증은 authService에 있는 메소드를 사용하도록 구현
그 외에 코드는 새로 만든 User* 에서 작업하였습니다. 
