### PR TITLE
Feat/#26 가계부 달력 기능 

### DIFF
--- a/src/main/java/finance_us/finance_us/domain/account/controller/AccountController.java
+++ b/src/main/java/finance_us/finance_us/domain/account/controller/AccountController.java
@@ -8,10 +8,11 @@ import finance_us.finance_us.domain.account.service.AccountService;
 import finance_us.finance_us.global.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.security.core.Authentication;
 
 
 @RestController
-@RequestMapping("/account")
+@RequestMapping("/api/account")
 @RequiredArgsConstructor
 public class AccountController {
 
@@ -19,8 +20,8 @@ public class AccountController {
 
     // 가계부 생성
     @PostMapping
-    public ApiResponse<AccountResponse.AccountResponseDTO> createAccount(@RequestBody AccountRequest.AccountRequestDTO request){
-        Account account = accountService.createAccount(request);
+    public ApiResponse<AccountResponse.AccountResponseDTO> createAccount(@RequestBody AccountRequest.AccountRequestDTO request, Authentication authentication) {
+        Account account = accountService.createAccount(request, authentication);
         return ApiResponse.onSuccess(AccountConverter.toAccountResponseDTO(account));
     }
 

--- a/src/main/java/finance_us/finance_us/domain/account/controller/CalendarController.java
+++ b/src/main/java/finance_us/finance_us/domain/account/controller/CalendarController.java
@@ -1,0 +1,24 @@
+package finance_us.finance_us.domain.account.controller;
+
+
+import finance_us.finance_us.domain.account.dto.CalendarResponse;
+import finance_us.finance_us.domain.account.service.CalendarService;
+import finance_us.finance_us.global.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/calendar")
+@RequiredArgsConstructor
+public class CalendarController {
+    private final CalendarService calendarService;
+
+    // 가계부 달력 조회
+    @GetMapping("/{year}/{month}")
+    public ApiResponse<CalendarResponse.CalendarResponseDTO> getCalendar(@PathVariable Integer year, @PathVariable Integer month, Authentication authentication) {
+        CalendarResponse.CalendarResponseDTO response = calendarService.getCalendar(year, month, authentication);
+        return ApiResponse.onSuccess(response);
+    }
+
+}

--- a/src/main/java/finance_us/finance_us/domain/account/controller/CalendarController.java
+++ b/src/main/java/finance_us/finance_us/domain/account/controller/CalendarController.java
@@ -1,12 +1,17 @@
 package finance_us.finance_us.domain.account.controller;
 
 
+import finance_us.finance_us.domain.account.converter.CalendarConverter;
+import finance_us.finance_us.domain.account.dto.CalendarDetailResponse;
 import finance_us.finance_us.domain.account.dto.CalendarResponse;
+import finance_us.finance_us.domain.account.entity.Account;
 import finance_us.finance_us.domain.account.service.CalendarService;
 import finance_us.finance_us.global.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/calendar")
@@ -19,6 +24,18 @@ public class CalendarController {
     public ApiResponse<CalendarResponse.CalendarResponseDTO> getCalendar(@PathVariable Integer year, @PathVariable Integer month, Authentication authentication) {
         CalendarResponse.CalendarResponseDTO response = calendarService.getCalendar(year, month, authentication);
         return ApiResponse.onSuccess(response);
+    }
+
+    // 가계부 달력 일별 조회
+    @GetMapping("/{year}/{month}/{day}")
+    public ApiResponse<List<CalendarDetailResponse.CalendarDetailResponseDTO>> getCalendarDetail(
+            @PathVariable Integer year,
+            @PathVariable Integer month,
+            @PathVariable Integer day,
+            Authentication authentication) {
+
+        List<Account> accounts = calendarService.getCalendarDetail(year, month, day, authentication);
+        return ApiResponse.onSuccess(CalendarConverter.toCalendarDetailResponseDTOList(accounts));
     }
 
 }

--- a/src/main/java/finance_us/finance_us/domain/account/converter/CalendarConverter.java
+++ b/src/main/java/finance_us/finance_us/domain/account/converter/CalendarConverter.java
@@ -1,0 +1,17 @@
+package finance_us.finance_us.domain.account.converter;
+
+import finance_us.finance_us.domain.account.dto.CalendarResponse;
+
+import java.util.List;
+public class CalendarConverter {
+    public static CalendarResponse.CalendarResponseDTO toCalendarResponseDTO(
+            Double totalScore, Double totalExpense, Double totalIncome, List<CalendarResponse.CalendarDTO> calendar
+            ) {
+        return CalendarResponse.CalendarResponseDTO.builder()
+                .totalScore(totalScore)
+                .totalExpense(totalExpense)
+                .totalIncome(totalIncome)
+                 .calendar(calendar)
+                .build();
+    }
+}

--- a/src/main/java/finance_us/finance_us/domain/account/converter/CalendarConverter.java
+++ b/src/main/java/finance_us/finance_us/domain/account/converter/CalendarConverter.java
@@ -1,9 +1,14 @@
 package finance_us.finance_us.domain.account.converter;
 
+import finance_us.finance_us.domain.account.dto.CalendarDetailResponse;
 import finance_us.finance_us.domain.account.dto.CalendarResponse;
+import finance_us.finance_us.domain.account.entity.Account;
 
 import java.util.List;
+import java.util.stream.Collectors;
+
 public class CalendarConverter {
+    // 가계부 달력 조회
     public static CalendarResponse.CalendarResponseDTO toCalendarResponseDTO(
             Double totalScore, Double totalExpense, Double totalIncome, List<CalendarResponse.CalendarDTO> calendar
             ) {
@@ -13,5 +18,19 @@ public class CalendarConverter {
                 .totalIncome(totalIncome)
                  .calendar(calendar)
                 .build();
+    }
+
+    // 가계부 달력 일별 조회
+    public static List<CalendarDetailResponse.CalendarDetailResponseDTO> toCalendarDetailResponseDTOList(List<Account> accounts) {
+        return accounts.stream()
+                .map(account -> new CalendarDetailResponse.CalendarDetailResponseDTO(
+                        account.getId(),
+                        account.getScore(),
+                        account.getTitle(),
+                        account.getAmount(),
+                        account.getSubCategory().getSubName(),
+                        account.getImageUrl()
+                ))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/finance_us/finance_us/domain/account/dto/CalendarDetailResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/account/dto/CalendarDetailResponse.java
@@ -1,0 +1,21 @@
+package finance_us.finance_us.domain.account.dto;
+
+import lombok.*;
+
+public class CalendarDetailResponse {
+
+    // 가계부 달력 일별 조회
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CalendarDetailResponseDTO {
+        private Long accountId;
+        private int score;
+        private String title;
+        private Long amount;
+        private String subName;
+        private String imageUrl;
+    }
+}

--- a/src/main/java/finance_us/finance_us/domain/account/dto/CalendarResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/account/dto/CalendarResponse.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 public class CalendarResponse {
 
+    // 가계부 달력 조회
     @Getter
     @Setter
     @NoArgsConstructor
@@ -26,4 +27,5 @@ public class CalendarResponse {
     public static class CalendarDTO {
         private String date;
     }
+
 }

--- a/src/main/java/finance_us/finance_us/domain/account/dto/CalendarResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/account/dto/CalendarResponse.java
@@ -1,0 +1,29 @@
+package finance_us.finance_us.domain.account.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+public class CalendarResponse {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CalendarResponseDTO {
+        private Double totalScore;
+        private Double totalExpense;
+        private Double totalIncome;
+        private List<CalendarDTO> calendar;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class CalendarDTO {
+        private String date;
+    }
+}

--- a/src/main/java/finance_us/finance_us/domain/account/entity/Account.java
+++ b/src/main/java/finance_us/finance_us/domain/account/entity/Account.java
@@ -3,7 +3,6 @@ package finance_us.finance_us.domain.account.entity;
 import finance_us.finance_us.domain.account.entity.status.AccountType;
 import finance_us.finance_us.domain.category.entity.SubAsset;
 import finance_us.finance_us.domain.category.entity.SubCategory;
-import finance_us.finance_us.domain.common.entity.BaseEntity;
 import finance_us.finance_us.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -11,7 +10,7 @@ import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
 import org.w3c.dom.Text;
 
-import java.time.LocalDateTime;
+import java.time.LocalDate;
 
 @Entity
 @Getter
@@ -21,7 +20,7 @@ import java.time.LocalDateTime;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class Account extends BaseEntity {
+public class Account {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -29,6 +28,8 @@ public class Account extends BaseEntity {
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private AccountType accountType;
+
+    private LocalDate date;
 
     @Column(nullable = false)
     private Long amount;
@@ -39,10 +40,10 @@ public class Account extends BaseEntity {
     @Column(nullable = false)
     private Boolean status;
 
-    private String content;
-
     @Column(nullable = false)
     private int score;
+
+    private String content;
 
     private int totalLike;
 
@@ -50,7 +51,6 @@ public class Account extends BaseEntity {
 
     private String imageUrl;
 
-    private LocalDateTime date;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")

--- a/src/main/java/finance_us/finance_us/domain/account/repository/AccountRepository.java
+++ b/src/main/java/finance_us/finance_us/domain/account/repository/AccountRepository.java
@@ -31,5 +31,10 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
     // 년도와 월을 기준으로 데이터 조회
     @Query("SELECT a FROM Account a WHERE a.user.id = :userId AND YEAR(a.date) = :year AND MONTH(a.date) = :month")
     List<Account> findByUserIdAndYearAndMonth(Long userId, Integer year, Integer month);
+
+    // 년도와 월, 일을 기준으로 데이터 조회
+    @Query("SELECT a FROM Account a WHERE a.user.id = :userId AND YEAR(a.date) = :year AND MONTH(a.date) = :month AND DAY(a.date) = :day")
+    List<Account> findByUserIdAndYearAndMonthAndDay(Long userId, Integer year, Integer month, Integer day);
+
 }
 

--- a/src/main/java/finance_us/finance_us/domain/account/repository/AccountRepository.java
+++ b/src/main/java/finance_us/finance_us/domain/account/repository/AccountRepository.java
@@ -28,4 +28,8 @@ public interface AccountRepository extends JpaRepository<Account, Long> {
             @Param("user")User user
     );
 
+    // 년도와 월을 기준으로 데이터 조회
+    @Query("SELECT a FROM Account a WHERE a.user.id = :userId AND YEAR(a.date) = :year AND MONTH(a.date) = :month")
+    List<Account> findByUserIdAndYearAndMonth(Long userId, Integer year, Integer month);
 }
+

--- a/src/main/java/finance_us/finance_us/domain/account/service/CalendarService.java
+++ b/src/main/java/finance_us/finance_us/domain/account/service/CalendarService.java
@@ -70,4 +70,15 @@ public class CalendarService {
         // DTO 반환
         return CalendarConverter.toCalendarResponseDTO(totalScore, totalExpense, totalIncome, calendar);
     }
+
+
+    // 가계부 달별 일별 조회
+    public List<Account> getCalendarDetail(Integer year, Integer month, Integer day, Authentication authentication) {
+        // userId 추출
+        Long userId = (Long) authentication.getPrincipal();
+
+        // 해당 년도, 월, 일에 해당하는 Account 데이터를 조회
+        return accountRepository.findByUserIdAndYearAndMonthAndDay(userId, year, month, day);
+    }
+
 }

--- a/src/main/java/finance_us/finance_us/domain/account/service/CalendarService.java
+++ b/src/main/java/finance_us/finance_us/domain/account/service/CalendarService.java
@@ -1,0 +1,73 @@
+package finance_us.finance_us.domain.account.service;
+
+import finance_us.finance_us.domain.account.converter.CalendarConverter;
+import finance_us.finance_us.domain.account.dto.CalendarResponse;
+import finance_us.finance_us.domain.account.entity.Account;
+import finance_us.finance_us.domain.account.entity.status.AccountType;
+import finance_us.finance_us.domain.account.repository.AccountRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Service
+@RequiredArgsConstructor
+public class CalendarService {
+    private final AccountRepository accountRepository;
+
+    // 가계부 달력 조회
+    public CalendarResponse.CalendarResponseDTO getCalendar(Integer year, Integer month, Authentication auth) {
+        // userId 추출
+        Long userId = (Long) auth.getPrincipal();
+
+        // 해당 년도와 월에 해당하는 Account 데이터 조회
+        List<Account> accounts = accountRepository.findByUserIdAndYearAndMonth(userId, year, month);
+
+        // 총 별점
+        double total = 0.0;
+        for (Account account : accounts) {
+            total += account.getScore();
+        }
+
+        // 평균 별점
+        double totalScore = 0.0;
+        if (!accounts.isEmpty()) {
+            totalScore = total / accounts.size();
+            totalScore = Math.round(totalScore * 10.0) / 10.0;  // 소수점 첫째 자리로 반올림
+        }
+
+        // 총 지출
+        double totalExpense = 0.0;
+        for (Account account : accounts) {
+            if (account.getAccountType() == AccountType.expense) {
+                totalExpense += account.getAmount();
+            }
+        }
+
+        // 총 수입
+        double totalIncome = 0.0;
+        for (Account account : accounts) {
+            if (account.getAccountType() == AccountType.income) {
+                totalIncome += account.getAmount();
+            }
+        }
+
+        // 날짜 리스트 생성 (중복되지 않도록 Set을 사용)
+        Set<String> dates = new HashSet<>();
+        for (Account account : accounts) {
+            dates.add(account.getDate().toString());
+        }
+
+        // Set을 List로 변환하여 CalendarDTO 생성
+        List<CalendarResponse.CalendarDTO> calendar = dates.stream()
+                .map(date -> new CalendarResponse.CalendarDTO(date))
+                .toList();
+
+
+        // DTO 반환
+        return CalendarConverter.toCalendarResponseDTO(totalScore, totalExpense, totalIncome, calendar);
+    }
+}


### PR DESCRIPTION
## 💡 관련 이슈
- #26 

## 🎋 요약
- 가계부 달력 불러오기 기능 구현하였습니다. 

## ⚡️ 상세 내용
- 가계부 달력 불러오기 API
- 가계부 달력 일별 불러오기 API

## 🔑 주요 변경사항
- api URI 수정하였습니다 (/account -> /api/account) 
- account entity 변경된 부분 다시 수정하였습니다 
- 임의로 userId를 할당해준 부분을 Authentication를 사용하여 user를 불러왔습니다.
