### PR TITLE
[#19] Feat : 알림 API 구현

### DIFF
--- a/src/main/java/finance_us/finance_us/domain/notifications/controller/NotificationController.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/controller/NotificationController.java
@@ -1,0 +1,50 @@
+package finance_us.finance_us.domain.notifications.controller;
+
+import finance_us.finance_us.domain.notifications.dto.NotificationListResponse;
+import finance_us.finance_us.domain.notifications.dto.NotificationResponse;
+import finance_us.finance_us.domain.notifications.dto.UnreadNotificationsResponse;
+import finance_us.finance_us.domain.notifications.service.NotificationService;
+import finance_us.finance_us.global.ApiResponse;
+import finance_us.finance_us.security.TokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+    private final NotificationService notificationService;
+    private final TokenProvider tokenProvider;
+
+    @GetMapping
+    public ApiResponse<NotificationListResponse> getNotifications(
+            @RequestParam(required = false) Long lastNotificationId,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam Long userId
+            //@RequestHeader("Authorization") String token
+    ) {
+        NotificationListResponse response = notificationService.getNotifications(lastNotificationId, size, userId);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @GetMapping("/unread")
+    public ApiResponse<UnreadNotificationsResponse> hasUnreadNotifications(
+            @RequestParam Long userId
+            //@RequestHeader("Authorization") String token
+    ){
+        UnreadNotificationsResponse response = notificationService.hasUnreadNotifications(userId);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @PatchMapping("/{notificationId}")
+    public ApiResponse<Void> markAsRead(
+            @PathVariable Long notificationId,
+            @RequestParam Long userId
+            //@RequestHeader("Authorization") String token
+    ){
+        notificationService.markAsRead(notificationId, userId);
+        return ApiResponse.onSuccess(null);
+    }
+}

--- a/src/main/java/finance_us/finance_us/domain/notifications/dto/NotificationListResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/dto/NotificationListResponse.java
@@ -1,0 +1,25 @@
+package finance_us.finance_us.domain.notifications.dto;
+
+import finance_us.finance_us.domain.notifications.entity.Notification;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class NotificationListResponse {
+    private List<NotificationResponse> notifications; // 알림 목록
+    private Long lastNotificationId; // 마지막 알림 ID
+
+    public static NotificationListResponse fromEntities(List<Notification> notifications) {
+        // 마지막 알림 ID를 첫 번째로 추출
+        Long lastNotificationId = notifications.isEmpty() ? null : notifications.get(notifications.size() - 1).getId();
+
+        List<NotificationResponse> notificationResponses = notifications.stream()
+                .map(NotificationResponse::fromEntity)
+                .toList();
+
+        return new NotificationListResponse(notificationResponses, lastNotificationId);
+    }
+}

--- a/src/main/java/finance_us/finance_us/domain/notifications/dto/NotificationResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/dto/NotificationResponse.java
@@ -1,0 +1,31 @@
+package finance_us.finance_us.domain.notifications.dto;
+
+import finance_us.finance_us.domain.notifications.entity.Notification;
+import finance_us.finance_us.domain.notifications.entity.status.ResourceType;
+import finance_us.finance_us.domain.notifications.entity.status.Type;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+@AllArgsConstructor
+public class NotificationResponse {
+    private Long id;
+    private Type type;
+    private String message;
+    private ResourceType resourceType;
+    private Long resourceId;
+    private Boolean isRead;
+
+    public static NotificationResponse fromEntity(Notification notification) {
+        return new NotificationResponse(
+                notification.getId(),
+                notification.getType(),
+                notification.getMessage(),
+                notification.getResourceType(),
+                notification.getResourceId(),
+                notification.getIsRead()
+        );
+    }
+}

--- a/src/main/java/finance_us/finance_us/domain/notifications/dto/UnreadNotificationsResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/dto/UnreadNotificationsResponse.java
@@ -1,0 +1,10 @@
+package finance_us.finance_us.domain.notifications.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UnreadNotificationsResponse {
+    private boolean hasUnread;
+}

--- a/src/main/java/finance_us/finance_us/domain/notifications/entity/Notification.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/entity/Notification.java
@@ -1,6 +1,8 @@
 package finance_us.finance_us.domain.notifications.entity;
 
 import finance_us.finance_us.domain.common.entity.BaseEntity;
+import finance_us.finance_us.domain.notifications.entity.status.ResourceType;
+import finance_us.finance_us.domain.notifications.entity.status.Type;
 import finance_us.finance_us.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -9,6 +11,7 @@ import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Getter
+@Setter
 @DynamicUpdate
 @DynamicInsert
 @Builder
@@ -19,14 +22,14 @@ public class Notification extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    //@Enumerated(EnumType.STRING)
-    //private Type type;
+    @Enumerated(EnumType.STRING)
+    private Type type;
 
     private String message;
 
-    //@Enumerated(EnumType.STRING)
-    //@Column(nullable = false)
-    //private ResourceType resourceType;
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private ResourceType resourceType;
 
     @Column(nullable = false)
     private Long resourceId;

--- a/src/main/java/finance_us/finance_us/domain/notifications/entity/status/ResourceType.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/entity/status/ResourceType.java
@@ -1,0 +1,5 @@
+package finance_us.finance_us.domain.notifications.entity.status;
+
+public enum ResourceType {
+    POST, ACCOUNT
+}

--- a/src/main/java/finance_us/finance_us/domain/notifications/entity/status/Type.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/entity/status/Type.java
@@ -1,0 +1,5 @@
+package finance_us.finance_us.domain.notifications.entity.status;
+
+public enum Type {
+    COMMENT, REPLY, LIKE, EMOJI, FOLLOW
+}

--- a/src/main/java/finance_us/finance_us/domain/notifications/repository/NotificationRepository.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/repository/NotificationRepository.java
@@ -1,0 +1,33 @@
+package finance_us.finance_us.domain.notifications.repository;
+
+import finance_us.finance_us.domain.notifications.entity.Notification;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+ /*   @Query("SELECT n FROM Notification n WHERE n.user.Id = :userId ORDER BY n.createdAt DESC")
+    List<Notification> findByUserOrderByCreatedAtDesc(Long userId);
+
+    List<Notification> findByUserIdAndIsReadFalseOrderByCreatedAtDesc(Long userId);*/
+
+    @Query("SELECT COUNT(n) > 0 FROM Notification n WHERE n.user.Id = :userId AND n.isRead = false")
+    boolean existsUnreadNotificationsForUserId(@Param("userId") Long userId);
+
+    // 첫 조회: 최신 알림
+    @Query("SELECT n FROM Notification n WHERE n.user.Id = :userId AND n.isRead = false ORDER BY n.createdAt DESC")
+    List<Notification> findTopByUserIdAAndIsReadFalseOrderByCreatedAtDescOrderByCreatedAtDesc(@Param("userId") Long userId, Pageable pageable);
+
+    // 스크롤: 특정 ID 이후 알림
+    @Query("SELECT n FROM Notification n WHERE n.user.Id = :userId AND n.id < :lastNotificationId AND n.isRead = false ORDER BY n.createdAt DESC")
+    List<Notification> findByUserIdAndIdANDIsReadFalseLessThanOrderByCreatedAtDesc(
+            @Param("userId") Long userId,
+            @Param("lastNotificationId") Long lastNotificationId,
+            Pageable pageable
+    );
+}

--- a/src/main/java/finance_us/finance_us/domain/notifications/service/NotificationService.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/service/NotificationService.java
@@ -1,0 +1,60 @@
+package finance_us.finance_us.domain.notifications.service;
+
+import finance_us.finance_us.domain.notifications.dto.NotificationListResponse;
+import finance_us.finance_us.domain.notifications.dto.NotificationResponse;
+import finance_us.finance_us.domain.notifications.dto.UnreadNotificationsResponse;
+import finance_us.finance_us.domain.notifications.entity.Notification;
+import finance_us.finance_us.domain.notifications.repository.NotificationRepository;
+import finance_us.finance_us.global.code.status.ErrorStatus;
+import finance_us.finance_us.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+    private final NotificationRepository notificationRepository;
+
+    @Transactional(readOnly = true)
+    public NotificationListResponse getNotifications(Long lastNotificationId, int size, Long userId) {
+        List<Notification> notifications;
+        PageRequest pageRequest = PageRequest.of(0, size);
+
+        if (lastNotificationId == null) {
+            // 첫 조회: 최신 알림부터 가져오기
+            notifications = notificationRepository.findTopByUserIdAAndIsReadFalseOrderByCreatedAtDescOrderByCreatedAtDesc(userId, pageRequest);
+        } else {
+            // 스크롤: 특정 ID 이후의 알림 가져오기
+            notifications = notificationRepository.findByUserIdAndIdANDIsReadFalseLessThanOrderByCreatedAtDesc(userId, lastNotificationId, pageRequest);
+        }
+
+        return NotificationListResponse.fromEntities(notifications);
+    }
+
+    @Transactional
+    public void markAsRead(Long notificationId, Long userId) {
+        Notification notification = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOTIFICATION_NOT_FOUND));
+
+        if(!notification.getUser().getId().equals(userId)) {
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_FOUND);
+        }
+
+        if(notification.getIsRead()) {
+            throw new GeneralException(ErrorStatus.NOTIFICATION_ALREADY_READ);
+        }
+        notification.setIsRead(true);
+        notificationRepository.save(notification);
+    }
+
+    @Transactional(readOnly = true)
+    public UnreadNotificationsResponse hasUnreadNotifications(Long userId) {
+        boolean hasUnread = notificationRepository.existsUnreadNotificationsForUserId(userId);
+        return new UnreadNotificationsResponse(hasUnread);
+    }
+}

--- a/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
+++ b/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
@@ -48,6 +48,10 @@ public enum ErrorStatus implements BaseErrorCode {
 
 
     CATEGORY_TYPE_ERROR(HttpStatus.BAD_REQUEST,"CATEGORY4001", "카테고리의 타입 문자열이 잘못되었습니다."),
+
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION4001", "조회할 알림 목록이 없습니다."),
+    NOTIFICATION_ALREADY_READ(HttpStatus.BAD_REQUEST, "NOTIFICATION4002", "이미 읽음처리 된 알람입니다."),
+
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트");
 
 


### PR DESCRIPTION
## 💡 관련 이슈
- #19 

## 🎋 요약
- 알림 API를 구현

## ⚡️ 상세 내용
- 알림 조회 기능(미확인 알림만 조회, 스크롤 기능 구현)
- 알림 읽음 처리 기능
- 미확인 알림 존재 여부 확인 기능

## 🔑 주요 변경사항
- 스웨거 테스트 완료
- 인증 부분은 아직 구현하지 않음
- 알림 생성 로직은 다른 분들의 관련 부분 구현이 끝난 후 추가할 예정
