### PR TITLE
Feat/#32 팔로우 API 구현

### DIFF
--- a/src/main/java/finance_us/finance_us/domain/follows/controller/FollowController.java
+++ b/src/main/java/finance_us/finance_us/domain/follows/controller/FollowController.java
@@ -1,0 +1,52 @@
+package finance_us.finance_us.domain.follows.controller;
+
+import finance_us.finance_us.domain.follows.dto.FollowResponse;
+import finance_us.finance_us.domain.follows.dto.FollowResponseWithLastId;
+import finance_us.finance_us.domain.follows.entity.Follow;
+import finance_us.finance_us.domain.follows.service.FollowService;
+import finance_us.finance_us.global.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/follows")
+@RequiredArgsConstructor
+public class FollowController {
+    private final FollowService followService;
+
+    @PostMapping("/{followingId}")
+    public ApiResponse<Void> addFollow(
+            @PathVariable Long followingId,
+            @RequestParam Long userId
+            //@RequestHeader("Authorization") String token
+    ) {
+        followService.addFollow(userId, followingId);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @DeleteMapping("/{followingId}")
+    public ApiResponse<Void> removeFollow(
+            @PathVariable Long followingId,
+            @RequestParam Long userId
+            //@RequestHeader("Authorization") String token
+    ) {
+        followService.removeFollow(userId, followingId);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @GetMapping
+    public ApiResponse<FollowResponseWithLastId> getFollows(
+            @RequestParam Long userId,
+            @RequestParam(required = false) Long lastfollowingId,
+            @RequestParam(defaultValue = "10") int size
+            //@RequestHeader("Authorization") String token
+    ) {
+        FollowResponseWithLastId follows = followService.getFollows(userId, lastfollowingId, size);
+        return ApiResponse.onSuccess(follows);
+    }
+}

--- a/src/main/java/finance_us/finance_us/domain/follows/dto/FollowResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/follows/dto/FollowResponse.java
@@ -1,0 +1,12 @@
+package finance_us.finance_us.domain.follows.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FollowResponse {
+    private Long followingId;
+    private String name;
+    //private String profileImage;
+}

--- a/src/main/java/finance_us/finance_us/domain/follows/dto/FollowResponseWithLastId.java
+++ b/src/main/java/finance_us/finance_us/domain/follows/dto/FollowResponseWithLastId.java
@@ -1,0 +1,13 @@
+package finance_us.finance_us.domain.follows.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class FollowResponseWithLastId {
+    private List<FollowResponse> result;
+    private Long lastId;
+}

--- a/src/main/java/finance_us/finance_us/domain/follows/repository/FollowRepository.java
+++ b/src/main/java/finance_us/finance_us/domain/follows/repository/FollowRepository.java
@@ -1,0 +1,26 @@
+package finance_us.finance_us.domain.follows.repository;
+
+import finance_us.finance_us.domain.follows.entity.Follow;
+import finance_us.finance_us.domain.notifications.entity.Notification;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    void deleteByUserIdAndFollowingId(Long userId, Long followingId);
+
+    List<Follow> findByUserId(Long userId);
+
+    boolean existsByUserIdAndFollowingId(Long userId, Long followingId);
+
+    @Query("SELECT f FROM Follow f WHERE f.user.Id = :userId AND f.followingId > :lastFollowingId ORDER BY f.createdAt ASC")
+    List<Follow> findByUserIdAndIdGreaterThan(
+            @Param("userId") Long userId,
+            @Param("lastFollowingId") Long lastFollowingId,
+            Pageable pageable);
+}

--- a/src/main/java/finance_us/finance_us/domain/follows/service/FollowService.java
+++ b/src/main/java/finance_us/finance_us/domain/follows/service/FollowService.java
@@ -1,0 +1,76 @@
+package finance_us.finance_us.domain.follows.service;
+
+import finance_us.finance_us.domain.follows.dto.FollowResponse;
+import finance_us.finance_us.domain.follows.dto.FollowResponseWithLastId;
+import finance_us.finance_us.domain.follows.entity.Follow;
+import finance_us.finance_us.domain.follows.repository.FollowRepository;
+import finance_us.finance_us.domain.notifications.service.NotificationService;
+import finance_us.finance_us.domain.user.entity.User;
+import finance_us.finance_us.domain.user.repository.UserRepository;
+import finance_us.finance_us.global.code.status.ErrorStatus;
+import finance_us.finance_us.global.exception.GeneralException;
+import lombok.AllArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@AllArgsConstructor
+public class FollowService {
+    private final FollowRepository followRepository;
+    private final UserRepository userRepository;
+    private final NotificationService notificationService;
+
+    @Transactional
+    public void addFollow(Long userId, Long followingId){
+        User user = userRepository.findById(userId).orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        boolean alreadyFollowing = followRepository.existsByUserIdAndFollowingId(userId, followingId);
+        if (alreadyFollowing) {
+            throw new GeneralException(ErrorStatus.ALREADY_FOLLOW);
+        }
+
+        Follow follow = Follow.builder()
+                .user(user)
+                .followingId(followingId)
+                .build();
+        followRepository.save(follow);
+
+        //알림테이블에 알림 추가
+
+        notificationService.addFollowNotification(followingId, userId);
+    }
+
+    @Transactional
+    public void removeFollow(Long userId, Long followingId){
+
+        boolean alreadyFollowing = followRepository.existsByUserIdAndFollowingId(userId, followingId);
+        if (!alreadyFollowing) {
+            throw new GeneralException(ErrorStatus.FOLLOW_NOT_FOUND);
+        }
+        followRepository.deleteByUserIdAndFollowingId(userId, followingId);
+    }
+
+    public FollowResponseWithLastId getFollows(Long userId, Long lastFollowingId, int size) {
+
+        lastFollowingId = (lastFollowingId == null) ? 0 : lastFollowingId;
+
+        PageRequest pageRequest = PageRequest.of(0, size);
+
+        List<Follow> follows = followRepository.findByUserIdAndIdGreaterThan(userId, lastFollowingId, pageRequest);
+
+        List<FollowResponse> response = follows.stream()
+                .map(follow -> new FollowResponse(
+                        follow.getFollowingId(),
+                        follow.getUser().getName()))
+                .collect(Collectors.toList());
+
+        Long lastId = follows.isEmpty() ? null : follows.get(follows.size() -1).getFollowingId();
+
+        return new FollowResponseWithLastId(response, lastId);
+    }
+}

--- a/src/main/java/finance_us/finance_us/domain/notifications/entity/Notification.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/entity/Notification.java
@@ -28,10 +28,8 @@ public class Notification extends BaseEntity {
     private String message;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
     private ResourceType resourceType;
 
-    @Column(nullable = false)
     private Long resourceId;
 
     @Column(nullable = false)

--- a/src/main/java/finance_us/finance_us/domain/notifications/service/NotificationService.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/service/NotificationService.java
@@ -4,7 +4,10 @@ import finance_us.finance_us.domain.notifications.dto.NotificationListResponse;
 import finance_us.finance_us.domain.notifications.dto.NotificationResponse;
 import finance_us.finance_us.domain.notifications.dto.UnreadNotificationsResponse;
 import finance_us.finance_us.domain.notifications.entity.Notification;
+import finance_us.finance_us.domain.notifications.entity.status.Type;
 import finance_us.finance_us.domain.notifications.repository.NotificationRepository;
+import finance_us.finance_us.domain.user.entity.User;
+import finance_us.finance_us.domain.user.repository.UserRepository;
 import finance_us.finance_us.global.code.status.ErrorStatus;
 import finance_us.finance_us.global.exception.GeneralException;
 import lombok.RequiredArgsConstructor;
@@ -19,6 +22,7 @@ import java.util.stream.Collectors;
 @RequiredArgsConstructor
 public class NotificationService {
     private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public NotificationListResponse getNotifications(Long lastNotificationId, int size, Long userId) {
@@ -56,5 +60,24 @@ public class NotificationService {
     public UnreadNotificationsResponse hasUnreadNotifications(Long userId) {
         boolean hasUnread = notificationRepository.existsUnreadNotificationsForUserId(userId);
         return new UnreadNotificationsResponse(hasUnread);
+    }
+
+    public void addFollowNotification(Long targetUserId, Long followerId){
+        User targetUser = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        User follower = userRepository.findById(followerId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        String message = follower.getName() + "님이 팔로우 했습니다.";
+
+        Notification notification = Notification.builder()
+                .type(Type.FOLLOW)
+                .message(message)
+                .isRead(false)
+                .user(targetUser)
+                .build();
+
+        notificationRepository.save(notification);
+
     }
 }

--- a/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
+++ b/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
@@ -52,6 +52,9 @@ public enum ErrorStatus implements BaseErrorCode {
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION4001", "조회할 알림 목록이 없습니다."),
     NOTIFICATION_ALREADY_READ(HttpStatus.BAD_REQUEST, "NOTIFICATION4002", "이미 읽음처리 된 알람입니다."),
 
+    FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLLOW4001", "팔로우 되지 않은 사용자입니다."),
+    ALREADY_FOLLOW(HttpStatus.BAD_REQUEST, "FOLLOW4002", "이미 팔로우 된 사용자입니다."),
+
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트");
 
 


### PR DESCRIPTION
## 💡 관련 이슈
- #32 

## 🎋 요약
- 팔로우 API 구현

## ⚡️ 상세 내용
- 팔로우 추가 기능 구현
- 팔로우 취소 기능 구현
- 팔로우 목록 조회 기능 구현

## 🔑 주요 변경사항
- 팔로우 생성 시 팔로우 당한 사람을 대상으로 한 알림 생성 로직 추가
- 스웨거를 통한 테스트 완료
