### PR TITLE
Feat/#45 검색 API 구현

### DIFF
--- a/src/main/java/finance_us/finance_us/domain/post/repository/PostRepository.java
+++ b/src/main/java/finance_us/finance_us/domain/post/repository/PostRepository.java
@@ -1,6 +1,8 @@
 package finance_us.finance_us.domain.post.repository;
 
 import finance_us.finance_us.domain.post.entity.Post;
+import finance_us.finance_us.domain.post.entity.status.PostType;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -22,5 +24,13 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query(value="select p.* from post_scrap ps inner join post p on p.id=ps.post_id where ps.user_id=:userId ;", nativeQuery=true)
     public List<Post> findByUserScraped(@Param("userId") Long userId);
+
+    //게시판 유형, 키워드를 통한 조회
+    @Query("SELECT p FROM Post p WHERE p.postType = :boardType AND p.id > :lastId And (p.title LIKE %:keyword% OR p.content LIKE %:keyword%) ORDER BY p.id ASC")
+    List<Post> findByCategoryAndKeywordWithPaging(
+            @Param("boardType") PostType boardType,
+            @Param("lastId") Long lastId,
+            @Param("keyword") String keyword,
+            Pageable pageable);
 
 }

--- a/src/main/java/finance_us/finance_us/domain/search/controller/SearchController.java
+++ b/src/main/java/finance_us/finance_us/domain/search/controller/SearchController.java
@@ -1,0 +1,46 @@
+package finance_us.finance_us.domain.search.controller;
+
+import finance_us.finance_us.domain.post.entity.Post;
+import finance_us.finance_us.domain.post.entity.status.PostType;
+import finance_us.finance_us.domain.search.dto.PostSearchResponse;
+import finance_us.finance_us.domain.search.dto.UserSearchResponse;
+import finance_us.finance_us.domain.search.service.SearchService;
+import finance_us.finance_us.global.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/search")
+@RequiredArgsConstructor
+public class SearchController {
+    private final SearchService searchService;
+
+    @GetMapping("/posts")
+    public ApiResponse<PostSearchResponse> searchPosts(
+            @RequestParam PostType boardType,
+            @RequestParam(required = false) Long lastId,
+            @RequestParam String keyword,
+            @RequestParam(defaultValue = "10") int size)
+    {
+        PostSearchResponse response = searchService.searchPosts(boardType, lastId, keyword, size);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @GetMapping("/users")
+    public ApiResponse<UserSearchResponse> searchUsers(
+            @RequestParam String keyword,
+            @RequestParam(required = false) Long lastId,
+            @RequestParam Long currentUserId,
+            @RequestParam(defaultValue = "10") int size)
+    {
+
+        UserSearchResponse response = searchService.searchUsers(keyword, lastId, currentUserId, size);
+        return ApiResponse.onSuccess(response);
+    }
+}

--- a/src/main/java/finance_us/finance_us/domain/search/dto/PostResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/search/dto/PostResponse.java
@@ -1,0 +1,16 @@
+package finance_us.finance_us.domain.search.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class PostResponse {
+    private Long postId;
+    private String title;
+    private String content;
+    private String author;
+    private String boardType;
+}

--- a/src/main/java/finance_us/finance_us/domain/search/dto/PostSearchResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/search/dto/PostSearchResponse.java
@@ -1,0 +1,13 @@
+package finance_us.finance_us.domain.search.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PostSearchResponse {
+    private List<PostResponse> posts;
+    private Long lastId;
+}

--- a/src/main/java/finance_us/finance_us/domain/search/dto/UserResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/search/dto/UserResponse.java
@@ -1,0 +1,13 @@
+package finance_us.finance_us.domain.search.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class UserResponse {
+    private Long userId;
+    private String username;
+    //private String profileImageUrl;
+    private boolean isFollowed;
+}

--- a/src/main/java/finance_us/finance_us/domain/search/dto/UserSearchResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/search/dto/UserSearchResponse.java
@@ -1,0 +1,13 @@
+package finance_us.finance_us.domain.search.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class UserSearchResponse {
+    private List<UserResponse> users;
+    private Long lastId;
+}

--- a/src/main/java/finance_us/finance_us/domain/search/service/SearchService.java
+++ b/src/main/java/finance_us/finance_us/domain/search/service/SearchService.java
@@ -1,0 +1,72 @@
+package finance_us.finance_us.domain.search.service;
+
+import finance_us.finance_us.domain.follows.repository.FollowRepository;
+import finance_us.finance_us.domain.follows.service.FollowService;
+import finance_us.finance_us.domain.post.entity.status.PostType;
+import finance_us.finance_us.domain.search.dto.PostResponse;
+import finance_us.finance_us.domain.post.entity.Post;
+import finance_us.finance_us.domain.post.repository.PostRepository;
+import finance_us.finance_us.domain.search.dto.PostSearchResponse;
+import finance_us.finance_us.domain.search.dto.UserResponse;
+import finance_us.finance_us.domain.search.dto.UserSearchResponse;
+import finance_us.finance_us.domain.user.entity.User;
+import finance_us.finance_us.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SearchService {
+    private final PostRepository postRepository;
+    private final UserRepository userRepository;
+    private final FollowService followService;
+    private final FollowRepository followRepository;
+
+    public PostSearchResponse searchPosts(
+            PostType boardType, Long lastId, String keyword, int size){
+        lastId = (lastId == null) ? 0 : lastId;
+
+        PageRequest pageRequest = PageRequest.of(0, size);
+
+        List<Post> posts = postRepository.findByCategoryAndKeywordWithPaging(boardType, lastId, keyword, pageRequest);
+
+        List<PostResponse> postDtos = posts.stream()
+                .map(post -> new PostResponse(
+                        post.getId(),
+                        post.getTitle(),
+                        post.getContent(),
+                        post.getUser().getName(),
+                        post.getPostType().toString()))
+                .collect(Collectors.toList());
+
+        Long newLastId = posts.isEmpty() ? null : posts.get(posts.size() - 1).getId();
+
+        return new PostSearchResponse(postDtos, newLastId);
+
+    }
+
+    public UserSearchResponse searchUsers(
+            String keyword, Long lastId, Long currentUserId, int size){
+
+        lastId = (lastId == null) ? 0 : lastId;
+        PageRequest pageRequest = PageRequest.of(0, size);
+
+        List<User> users = userRepository.findByNameContainingWithPagingAndExcludeSelf(keyword, lastId, currentUserId, pageRequest);
+
+        List<UserResponse> userDtos = users.stream()
+                .map(user -> new UserResponse(
+                        user.getId(),
+                        user.getName(),
+                        followRepository.existsByUserIdAndFollowingId(currentUserId, user.getId())))
+                .collect(Collectors.toList());
+
+        Long newLastId = users.isEmpty() ? null : users.get(users.size() - 1).getId();
+
+        return new UserSearchResponse(userDtos, newLastId);
+    }
+
+}

--- a/src/main/java/finance_us/finance_us/domain/user/repository/UserRepository.java
+++ b/src/main/java/finance_us/finance_us/domain/user/repository/UserRepository.java
@@ -1,9 +1,13 @@
 package finance_us.finance_us.domain.user.repository;
 
 import finance_us.finance_us.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -14,5 +18,13 @@ public interface UserRepository extends JpaRepository<User,String> {
 
     Optional<User> findById(Long id);
     Optional<User> findByName(String name);
+
+    //키워드로 사용자 조회 기능(자신 제외)
+    @Query("SELECT u FROM User u WHERE u.name LIKE %:keyword% AND u.Id > :lastId AND u.Id <> :currentUserId ORDER BY u.Id ASC")
+    List<User> findByNameContainingWithPagingAndExcludeSelf(
+            @Param("keyword") String keyword,
+            @Param("lastId") Long lastId,
+            @Param("currentUserId") Long currentUserId,
+            Pageable pageable);
 }
 


### PR DESCRIPTION
## 💡 관련 이슈
- #45 

## 🎋 요약
- 검색 API 구현

## ⚡️ 상세 내용
- 제목/내용 기반 검색 기능 구현(현재 게시판에 해당되는 글만 조회)
- 사용자 검색 기능 구현(자기 자신 제외)

## 🔑 주요 변경사항
- 스웨거를 통한 테스트 완료
- 추후 인증 로직 추가 예정
