### PR TITLE
Feat/#62 가계부 달력 일별 조회 필드값 추가 

### DIFF
--- a/src/main/java/finance_us/finance_us/domain/account/converter/CalendarConverter.java
+++ b/src/main/java/finance_us/finance_us/domain/account/converter/CalendarConverter.java
@@ -25,11 +25,15 @@ public class CalendarConverter {
         return accounts.stream()
                 .map(account -> new CalendarDetailResponse.CalendarDetailResponseDTO(
                         account.getId(),
-                        account.getScore(),
-                        account.getTitle(),
-                        account.getAmount(),
+                        account.getAccountType(),
+                        account.getDate(),
                         account.getSubCategory().getSubName(),
-                        account.getImageUrl()
+                        account.getSubAsset().getSubName(),
+                        account.getAmount(),
+                        account.getTitle(),
+                        account.getScore(),
+                        account.getImageUrl(),
+                        account.getContent()
                 ))
                 .collect(Collectors.toList());
     }

--- a/src/main/java/finance_us/finance_us/domain/account/dto/CalendarDetailResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/account/dto/CalendarDetailResponse.java
@@ -1,6 +1,9 @@
 package finance_us.finance_us.domain.account.dto;
 
+import finance_us.finance_us.domain.account.entity.status.AccountType;
 import lombok.*;
+
+import java.time.LocalDate;
 
 public class CalendarDetailResponse {
 
@@ -12,10 +15,14 @@ public class CalendarDetailResponse {
     @Builder
     public static class CalendarDetailResponseDTO {
         private Long accountId;
-        private int score;
-        private String title;
-        private Long amount;
+        private AccountType accountType;
+        private LocalDate date;
         private String subName;
+        private String subAssetName;
+        private Long amount;
+        private String title;
+        private int score;
         private String imageUrl;
+        private String content;
     }
 }


### PR DESCRIPTION
## 💡 관련 이슈
- #62 

## 🎋 요약
- 수정 시에 "accountType", "date", "subAssetName", "status" ,"content" 필드 값이 필요하여 해당 필드를 추가함 

## ⚡️ 상세 내용
-

## 🔑 주요 변경사항
-
