### PR TITLE
Feat/#76 S3 적용, 가계부 필드 추가 

### DIFF
--- a/src/main/java/finance_us/finance_us/domain/account/controller/AccountController.java
+++ b/src/main/java/finance_us/finance_us/domain/account/controller/AccountController.java
@@ -21,7 +21,6 @@ public class AccountController {
 
     private final AccountService accountService;
     private final LikeService likeService;
-    private final AccountImageService accountImageService;
     private final GoogleOcrService googleOcrService;
     private final AccountImageExtractService accountImageExtractService;
 
@@ -89,19 +88,6 @@ public class AccountController {
         }
 
         return ApiResponse.onSuccess( accountImageExtractService.extractAccountFromReceipt(extractedText));
-
-    }
-
-    // S3 이미지 업로드
-    @PostMapping(value = "/image", consumes = "multipart/form-data")
-    public ApiResponse<String> uploadImage(
-            @RequestHeader("Authorization") String token,
-            @RequestParam("file") MultipartFile file) {
-
-        String response =  accountImageService.saveImage(token, file);
-
-        return ApiResponse.onSuccess(response); // 업로드된 파일 URL 반환
-
 
     }
 

--- a/src/main/java/finance_us/finance_us/domain/account/controller/AccountController.java
+++ b/src/main/java/finance_us/finance_us/domain/account/controller/AccountController.java
@@ -3,10 +3,7 @@ package finance_us.finance_us.domain.account.controller;
 import finance_us.finance_us.domain.account.converter.AccountConverter;
 import finance_us.finance_us.domain.account.dto.*;
 import finance_us.finance_us.domain.account.entity.Account;
-import finance_us.finance_us.domain.account.service.AccountImageExtractService;
-import finance_us.finance_us.domain.account.service.AccountService;
-import finance_us.finance_us.domain.account.service.GoogleOcrService;
-import finance_us.finance_us.domain.account.service.LikeService;
+import finance_us.finance_us.domain.account.service.*;
 import finance_us.finance_us.global.ApiResponse;
 import finance_us.finance_us.global.code.status.ErrorStatus;
 import finance_us.finance_us.global.exception.GeneralException;
@@ -17,8 +14,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
-
-
 @RestController
 @RequestMapping("/api/account")
 @RequiredArgsConstructor
@@ -26,6 +21,7 @@ public class AccountController {
 
     private final AccountService accountService;
     private final LikeService likeService;
+    private final AccountImageService accountImageService;
     private final GoogleOcrService googleOcrService;
     private final AccountImageExtractService accountImageExtractService;
 
@@ -93,6 +89,19 @@ public class AccountController {
         }
 
         return ApiResponse.onSuccess( accountImageExtractService.extractAccountFromReceipt(extractedText));
+
+    }
+
+    // S3 이미지 업로드
+    @PostMapping(value = "/image", consumes = "multipart/form-data")
+    public ApiResponse<String> uploadImage(
+            @RequestHeader("Authorization") String token,
+            @RequestParam("file") MultipartFile file) {
+
+        String response =  accountImageService.saveImage(token, file);
+
+        return ApiResponse.onSuccess(response); // 업로드된 파일 URL 반환
+
 
     }
 

--- a/src/main/java/finance_us/finance_us/domain/account/converter/CalendarConverter.java
+++ b/src/main/java/finance_us/finance_us/domain/account/converter/CalendarConverter.java
@@ -33,6 +33,7 @@ public class CalendarConverter {
                         account.getTitle(),
                         account.getScore(),
                         account.getImageUrl(),
+                        account.getImageName(),
                         account.getContent()
                 ))
                 .collect(Collectors.toList());

--- a/src/main/java/finance_us/finance_us/domain/account/dto/AccountRequest.java
+++ b/src/main/java/finance_us/finance_us/domain/account/dto/AccountRequest.java
@@ -23,6 +23,7 @@ public class AccountRequest {
         private Boolean status;
         private Integer score;
         private String imageUrl;
+        private String imageName;
         private String content;
     }
 

--- a/src/main/java/finance_us/finance_us/domain/account/dto/CalendarDetailResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/account/dto/CalendarDetailResponse.java
@@ -23,6 +23,7 @@ public class CalendarDetailResponse {
         private String title;
         private int score;
         private String imageUrl;
+        private String imageName;
         private String content;
     }
 }

--- a/src/main/java/finance_us/finance_us/domain/account/dto/ReportResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/account/dto/ReportResponse.java
@@ -29,5 +29,6 @@ public class ReportResponse {
         private LocalDate date;
         private String subName;
         private String imageUrl;
+        private String imageName;
     }
 }

--- a/src/main/java/finance_us/finance_us/domain/account/entity/Account.java
+++ b/src/main/java/finance_us/finance_us/domain/account/entity/Account.java
@@ -49,6 +49,7 @@ public class Account {
     private int totalCheer;
 
     private String imageUrl;
+    private String imageName;
 
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/finance_us/finance_us/domain/account/service/AccountImageService.java
+++ b/src/main/java/finance_us/finance_us/domain/account/service/AccountImageService.java
@@ -1,0 +1,35 @@
+package finance_us.finance_us.domain.account.service;
+
+import finance_us.finance_us.global.code.status.ErrorStatus;
+import finance_us.finance_us.global.exception.GeneralException;
+import finance_us.finance_us.global.file.S3FileService;
+import finance_us.finance_us.security.TokenProvider;
+import jakarta.transaction.Transactional;
+import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+
+@Service
+@AllArgsConstructor
+public class AccountImageService {
+    private final S3FileService s3FileService;
+    private final TokenProvider tokenProvider;
+
+    //S3 이미지 업로드
+    @Transactional
+    public String saveImage(String token, MultipartFile file) {
+
+        tokenProvider.extractUserIdFromToken(token);
+        String imageUrl;
+        try {
+            // S3에 이미지 업로드
+            imageUrl = s3FileService.saveFile(file);
+        } catch (IOException e) {
+            throw new GeneralException(ErrorStatus.IMAGE_FAILED);
+        }
+
+        return imageUrl;
+    }
+}

--- a/src/main/java/finance_us/finance_us/domain/account/service/AccountService.java
+++ b/src/main/java/finance_us/finance_us/domain/account/service/AccountService.java
@@ -120,12 +120,14 @@ public class AccountService {
 
         // 필드 업데이트
         account.setAccountType(AccountType.valueOf(request.getAccountType()));
+        account.setDate(request.getDate());
         account.setAmount(request.getAmount());
         account.setTitle(request.getTitle());
         account.setStatus(request.getStatus());
         account.setScore(request.getScore());
         account.setContent(request.getContent());
         account.setImageUrl(request.getImageUrl());
+        account.setImageName(request.getImageName());
         account.setSubCategory(subCategory);
         account.setSubAsset(subAsset);
 

--- a/src/main/java/finance_us/finance_us/domain/account/service/AccountService.java
+++ b/src/main/java/finance_us/finance_us/domain/account/service/AccountService.java
@@ -173,7 +173,8 @@ public class AccountService {
                     account.getAmount(),
                     account.getDate(),
                     account.getSubCategory().getSubName(),
-                    account.getImageUrl()
+                    account.getImageUrl(),
+                    account.getImageName()
             );
 
             // 점수별로 분류

--- a/src/main/java/finance_us/finance_us/domain/account/service/AccountService.java
+++ b/src/main/java/finance_us/finance_us/domain/account/service/AccountService.java
@@ -70,6 +70,7 @@ public class AccountService {
                 .score(request.getScore())
                 .content(request.getContent())
                 .imageUrl(request.getImageUrl())
+                .imageName(request.getImageName())
                 .subCategory(subCategory)
                 .subAsset(subAsset)
                 .user(user)

--- a/src/main/java/finance_us/finance_us/global/S3/controller/S3Controller.java
+++ b/src/main/java/finance_us/finance_us/global/S3/controller/S3Controller.java
@@ -1,0 +1,31 @@
+package finance_us.finance_us.global.S3.controller;
+
+import finance_us.finance_us.global.ApiResponse;
+import finance_us.finance_us.global.S3.dto.S3Response;
+import finance_us.finance_us.global.S3.service.S3Service;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequestMapping("/api/account")
+@RequiredArgsConstructor
+public class S3Controller {
+    private final S3Service s3Service;
+
+    // S3 이미지 업로드
+    @PostMapping(value = "/image", consumes = "multipart/form-data")
+    public ApiResponse<S3Response.S3ResponseDTO> uploadImage(
+            @RequestHeader("Authorization") String token,
+            @RequestParam("file") MultipartFile file) {
+
+        S3Response.S3ResponseDTO response =  s3Service.saveS3(token, file);
+
+        return ApiResponse.onSuccess(response); // 업로드된 파일 URL 반환
+
+    }
+
+
+
+
+}

--- a/src/main/java/finance_us/finance_us/global/S3/controller/S3Controller.java
+++ b/src/main/java/finance_us/finance_us/global/S3/controller/S3Controller.java
@@ -4,8 +4,6 @@ import finance_us.finance_us.global.ApiResponse;
 import finance_us.finance_us.global.S3.dto.S3Request;
 import finance_us.finance_us.global.S3.dto.S3Response;
 import finance_us.finance_us.global.S3.service.S3Service;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;

--- a/src/main/java/finance_us/finance_us/global/S3/controller/S3Controller.java
+++ b/src/main/java/finance_us/finance_us/global/S3/controller/S3Controller.java
@@ -1,14 +1,17 @@
 package finance_us.finance_us.global.S3.controller;
 
 import finance_us.finance_us.global.ApiResponse;
+import finance_us.finance_us.global.S3.dto.S3Request;
 import finance_us.finance_us.global.S3.dto.S3Response;
 import finance_us.finance_us.global.S3.service.S3Service;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/api/account")
+@RequestMapping("/api")
 @RequiredArgsConstructor
 public class S3Controller {
     private final S3Service s3Service;
@@ -23,6 +26,16 @@ public class S3Controller {
 
         return ApiResponse.onSuccess(response); // 업로드된 파일 URL 반환
 
+    }
+
+    // 이미지 삭제
+    @DeleteMapping(value = "/image")
+    public ApiResponse<String> deleteImage(
+            @RequestHeader("Authorization") String token, @RequestBody S3Request request){
+        // 이전 이미지 삭제
+        s3Service.deleteS3(token, request);
+
+        return ApiResponse.onSuccess("삭제 완료되었습니다. ");
     }
 
 

--- a/src/main/java/finance_us/finance_us/global/S3/dto/S3Request.java
+++ b/src/main/java/finance_us/finance_us/global/S3/dto/S3Request.java
@@ -1,0 +1,14 @@
+package finance_us.finance_us.global.S3.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class S3Request {
+    private String imageName;
+}

--- a/src/main/java/finance_us/finance_us/global/S3/dto/S3Response.java
+++ b/src/main/java/finance_us/finance_us/global/S3/dto/S3Response.java
@@ -1,0 +1,15 @@
+package finance_us.finance_us.global.S3.dto;
+
+import lombok.*;
+
+public class S3Response {
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class S3ResponseDTO{
+        private String imageUrl;
+        private String imageName;
+    }
+}

--- a/src/main/java/finance_us/finance_us/global/S3/service/S3Service.java
+++ b/src/main/java/finance_us/finance_us/global/S3/service/S3Service.java
@@ -1,5 +1,7 @@
 package finance_us.finance_us.global.S3.service;
 
+import finance_us.finance_us.domain.user.entity.User;
+import finance_us.finance_us.global.S3.dto.S3Request;
 import finance_us.finance_us.global.S3.dto.S3Response;
 import finance_us.finance_us.global.code.status.ErrorStatus;
 import finance_us.finance_us.global.exception.GeneralException;
@@ -8,6 +10,7 @@ import finance_us.finance_us.security.TokenProvider;
 import jakarta.transaction.Transactional;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -34,6 +37,15 @@ public class S3Service {
         }
 
         return new S3Response.S3ResponseDTO(imageUrl, imageName);
+    }
+
+    //S3 삭제
+    @Transactional
+    public void deleteS3(String token, @RequestBody S3Request request){
+        tokenProvider.extractUserIdFromToken(token);
+
+        s3FileService.deleteImage(request.getImageName());
+
     }
 }
 

--- a/src/main/java/finance_us/finance_us/global/S3/service/S3Service.java
+++ b/src/main/java/finance_us/finance_us/global/S3/service/S3Service.java
@@ -1,5 +1,6 @@
-package finance_us.finance_us.domain.account.service;
+package finance_us.finance_us.global.S3.service;
 
+import finance_us.finance_us.global.S3.dto.S3Response;
 import finance_us.finance_us.global.code.status.ErrorStatus;
 import finance_us.finance_us.global.exception.GeneralException;
 import finance_us.finance_us.global.file.S3FileService;
@@ -10,19 +11,21 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.UUID;
 
 @Service
 @AllArgsConstructor
-public class AccountImageService {
+public class S3Service {
     private final S3FileService s3FileService;
     private final TokenProvider tokenProvider;
 
     //S3 이미지 업로드
     @Transactional
-    public String saveImage(String token, MultipartFile file) {
+    public S3Response.S3ResponseDTO saveS3(String token, MultipartFile file) {
 
         tokenProvider.extractUserIdFromToken(token);
         String imageUrl;
+        String imageName = UUID.randomUUID().toString() + "_" +file.getOriginalFilename();
         try {
             // S3에 이미지 업로드
             imageUrl = s3FileService.saveFile(file);
@@ -30,6 +33,7 @@ public class AccountImageService {
             throw new GeneralException(ErrorStatus.IMAGE_FAILED);
         }
 
-        return imageUrl;
+        return new S3Response.S3ResponseDTO(imageUrl, imageName);
     }
 }
+


### PR DESCRIPTION
## 💡 관련 이슈
- #76 

## 🎋 요약
- 기존에 작성된 S3 저장 및 삭제 로직을 global 폴더로 이동한 후, 이미지를 저장하도록 적용하였습니다.

## ⚡️ 상세 내용
- S3에 이미지를 업로드한 후, imageURL과 imageName을 반환합니다.
- 가계부/게시글/프로필 생성 시, S3에서 받은 imageURL과 imageName을 request로 전달받아 저장합니다. 
- 조회 시, 이미지 수정이 필요할 경우 imageName을 response로 반환합니다.
## 🔑 주요 변경사항
- 필드 추가 
- date 추가 
