### PR TITLE
[#87] Refactor : 팔로우 목록 조회 시 전달 정보에 프로필 이미지 추가

### DIFF
--- a/src/main/java/finance_us/finance_us/domain/account/service/LikeService.java
+++ b/src/main/java/finance_us/finance_us/domain/account/service/LikeService.java
@@ -10,6 +10,7 @@ import finance_us.finance_us.domain.account.entity.AccountLike;
 import finance_us.finance_us.domain.account.repository.AccountRepository;
 import finance_us.finance_us.domain.account.repository.CheerRepository;
 import finance_us.finance_us.domain.account.repository.LikeRepository;
+import finance_us.finance_us.domain.notifications.service.NotificationService;
 import finance_us.finance_us.domain.user.entity.User;
 import finance_us.finance_us.domain.user.repository.UserRepository;
 import finance_us.finance_us.global.code.status.ErrorStatus;
@@ -28,6 +29,8 @@ public class LikeService {
     private final LikeRepository likeRepository;
     private final CheerRepository cheerRepository;
     private final TokenProvider tokenProvider;
+    //알림 서비스 추가
+    private final NotificationService notificationService;
 
 
     public LikeResponse.LikeResponseDTO createLike(LikeRequest.LikeRequestDTO request, String token) {
@@ -58,6 +61,9 @@ public class LikeService {
         // likeTotal 증가
         account.setTotalLike(account.getTotalLike() + 1);
         accountRepository.save(account);
+
+        //알림 추가
+        notificationService.addEmojiNotification(request.getAccountId(), userId);
 
         // 응답 생성
         return LikeResponse.LikeResponseDTO.builder()
@@ -96,6 +102,9 @@ public class LikeService {
         // likeTotal 증가
         account.setTotalCheer(account.getTotalCheer() + 1);
         accountRepository.save(account);
+
+        //알림 추가
+        notificationService.addEmojiNotification(request.getAccountId(), userId);
 
         // 응답 생성
         return CheerResponse.CheerResponseDTO.builder()

--- a/src/main/java/finance_us/finance_us/domain/comment/service/CommentLikeService.java
+++ b/src/main/java/finance_us/finance_us/domain/comment/service/CommentLikeService.java
@@ -6,6 +6,8 @@ import finance_us.finance_us.domain.comment.entity.Comment;
 import finance_us.finance_us.domain.comment.entity.CommentLike;
 import finance_us.finance_us.domain.comment.repository.CommentLikeRepository;
 import finance_us.finance_us.domain.comment.repository.CommentRepository;
+import finance_us.finance_us.domain.notifications.entity.Notification;
+import finance_us.finance_us.domain.notifications.service.NotificationService;
 import finance_us.finance_us.domain.user.entity.User;
 import finance_us.finance_us.domain.user.repository.UserRepository;
 import finance_us.finance_us.security.TokenProvider;
@@ -19,6 +21,8 @@ public class CommentLikeService {
     private final CommentRepository commentRepository;
     private final UserRepository userRepository;
     private final TokenProvider tokenProvider;
+    //알림 서비스 추가
+    private final NotificationService notificationService;
 
     // 댓글 좋아요 추가
     public CommentLikeResponse.CommentLikeResponseDTO likeComment(String token, Long commentId) {
@@ -46,6 +50,9 @@ public class CommentLikeService {
         commentLikeRepository.save(commentLike);
 
         Long likesCount = commentLikeRepository.countLikesByCommentId(commentId);
+
+        // 알림 추가
+        notificationService.addCommentLikeNotification(commentId, userId);
 
         return CommentLikeConverter.toCommentLikeResponseDTO(commentLike, likesCount);
     }

--- a/src/main/java/finance_us/finance_us/domain/comment/service/CommentService.java
+++ b/src/main/java/finance_us/finance_us/domain/comment/service/CommentService.java
@@ -3,6 +3,7 @@ package finance_us.finance_us.domain.comment.service;
 import finance_us.finance_us.domain.comment.dto.CommentRequest;
 import finance_us.finance_us.domain.comment.entity.Comment;
 import finance_us.finance_us.domain.comment.repository.CommentRepository;
+import finance_us.finance_us.domain.notifications.service.NotificationService;
 import finance_us.finance_us.domain.post.entity.Post;
 import finance_us.finance_us.domain.post.repository.PostRepository;
 import finance_us.finance_us.domain.user.entity.User;
@@ -20,6 +21,8 @@ public class CommentService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final TokenProvider tokenProvider;
+    //알림 서비스 추가
+    private final NotificationService notificationService;
 
     // 댓글 생성
     public Comment createComment(String token, Long postId, CommentRequest.CommentRequestDTO request) {
@@ -38,6 +41,9 @@ public class CommentService {
                 .post(post)
                 .user(user)
                 .build();
+
+        // 알림 추가
+        notificationService.addCommentNotification(postId, userId);
 
         return commentRepository.save(comment);
     }

--- a/src/main/java/finance_us/finance_us/domain/follows/controller/FollowController.java
+++ b/src/main/java/finance_us/finance_us/domain/follows/controller/FollowController.java
@@ -5,6 +5,7 @@ import finance_us.finance_us.domain.follows.dto.FollowResponseWithLastId;
 import finance_us.finance_us.domain.follows.entity.Follow;
 import finance_us.finance_us.domain.follows.service.FollowService;
 import finance_us.finance_us.global.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -20,6 +21,7 @@ public class FollowController {
     private final FollowService followService;
 
     @PostMapping("/{followingId}")
+    @Operation(summary = "팔로우 추가 API")
     public ApiResponse<Void> addFollow(
             @RequestHeader("Authorization") String token,
             @PathVariable Long followingId
@@ -29,6 +31,7 @@ public class FollowController {
     }
 
     @DeleteMapping("/{followingId}")
+    @Operation(summary = "팔로우 취소 API")
     public ApiResponse<Void> removeFollow(
             @RequestHeader("Authorization") String token,
             @PathVariable Long followingId
@@ -38,12 +41,13 @@ public class FollowController {
     }
 
     @GetMapping
+    @Operation(summary = "팔로우 목록 조회(스크롤 포함) API")
     public ApiResponse<FollowResponseWithLastId> getFollows(
             @RequestHeader("Authorization") String token,
-            @RequestParam(required = false) Long lastfollowingId,
+            @RequestParam(required = false) Long lastFollowingId,
             @RequestParam(defaultValue = "10") int size
     ) {
-        FollowResponseWithLastId follows = followService.getFollows(token, lastfollowingId, size);
+        FollowResponseWithLastId follows = followService.getFollows(token, lastFollowingId, size);
         return ApiResponse.onSuccess(follows);
     }
 }

--- a/src/main/java/finance_us/finance_us/domain/follows/dto/FollowResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/follows/dto/FollowResponse.java
@@ -8,5 +8,5 @@ import lombok.Getter;
 public class FollowResponse {
     private Long followingId;
     private String name;
-    //private String profileImage;
+    private String profileImage;
 }

--- a/src/main/java/finance_us/finance_us/domain/follows/service/FollowService.java
+++ b/src/main/java/finance_us/finance_us/domain/follows/service/FollowService.java
@@ -73,7 +73,8 @@ public class FollowService {
 
                     return new FollowResponse(
                             follow.getFollowingId(),
-                            followingUser.getName()
+                            followingUser.getName(),
+                            followingUser.getImage()
                     );
                 })
                 .collect(Collectors.toList());

--- a/src/main/java/finance_us/finance_us/domain/notifications/service/NotificationService.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/service/NotificationService.java
@@ -1,11 +1,18 @@
 package finance_us.finance_us.domain.notifications.service;
 
+import finance_us.finance_us.domain.account.entity.Account;
+import finance_us.finance_us.domain.account.repository.AccountRepository;
+import finance_us.finance_us.domain.comment.entity.Comment;
+import finance_us.finance_us.domain.comment.repository.CommentRepository;
 import finance_us.finance_us.domain.notifications.dto.NotificationListResponse;
 import finance_us.finance_us.domain.notifications.dto.NotificationResponse;
 import finance_us.finance_us.domain.notifications.dto.UnreadNotificationsResponse;
 import finance_us.finance_us.domain.notifications.entity.Notification;
+import finance_us.finance_us.domain.notifications.entity.status.ResourceType;
 import finance_us.finance_us.domain.notifications.entity.status.Type;
 import finance_us.finance_us.domain.notifications.repository.NotificationRepository;
+import finance_us.finance_us.domain.post.entity.Post;
+import finance_us.finance_us.domain.post.repository.PostRepository;
 import finance_us.finance_us.domain.user.entity.User;
 import finance_us.finance_us.domain.user.repository.UserRepository;
 import finance_us.finance_us.global.code.status.ErrorStatus;
@@ -25,6 +32,9 @@ public class NotificationService {
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
     private final TokenProvider tokenProvider;
+    private final AccountRepository accountRepository;
+    private final PostRepository postRepository;
+    private final CommentRepository commentRepository;
 
     @Transactional(readOnly = true)
     public NotificationListResponse getNotifications(String token, Long lastNotificationId, int size) {
@@ -68,6 +78,7 @@ public class NotificationService {
         return new UnreadNotificationsResponse(hasUnread);
     }
 
+    //팔로우 시 알림 생성
     public void addFollowNotification(Long targetUserId, Long followerId){
         User targetUser = userRepository.findById(targetUserId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
@@ -85,5 +96,108 @@ public class NotificationService {
 
         notificationRepository.save(notification);
 
+    }
+
+    //가계부에 이모지 추가 시 알림 생성
+    public void addEmojiNotification(Long accountId, Long senderUserId) {
+        Account account = accountRepository.findById(accountId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ACCOUNT_NOT_FOUND));
+        User sender = userRepository.findById(senderUserId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 알림 대상은 가계부 주인
+        User targetUser = account.getUser();
+        if (targetUser.getId().equals(senderUserId)) return; // 자기 자신에게 알림 X
+
+        String message = "해당 가계부에 느낌을 표시했습니다.";
+
+        Notification notification = Notification.builder()
+                .type(Type.EMOJI)
+                .message(message)
+                .resourceType(ResourceType.ACCOUNT)
+                .resourceId(accountId)
+                .isRead(false)
+                .user(targetUser)
+                .build();
+
+        notificationRepository.save(notification);
+    }
+
+    //게시글에 좋아요 추가 시 알림 생성
+    public void addPostLikeNotification(Long postId, Long senderUserId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ARTICLE_NOT_FOUND));
+        User sender = userRepository.findById(senderUserId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 알림 대상은 게시글 주인
+        User targetUser = post.getUser();
+        if (targetUser.getId().equals(senderUserId)) return; // 자기 자신에게 알림 X
+
+        String message = "해당 게시글에 좋아요가 달렸습니다.";
+
+        Notification notification = Notification.builder()
+                .type(Type.LIKE)
+                .message(message)
+                .resourceType(ResourceType.POST)
+                .resourceId(postId)
+                .isRead(false)
+                .user(targetUser)
+                .build();
+
+        notificationRepository.save(notification);
+    }
+
+    //게시글에 댓글 추가 시 알림 생성
+    public void addCommentNotification(Long postId, Long senderUserId) {
+        Post post = postRepository.findById(postId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ARTICLE_NOT_FOUND));
+        User sender = userRepository.findById(senderUserId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 알림 대상은 게시글 주인
+        User targetUser = post.getUser();
+        if (targetUser.getId().equals(senderUserId)) return; // 자기 자신에게 알림 X
+
+        String message = "해당 게시글에 댓글이 달렸습니다.";
+
+        Notification notification = Notification.builder()
+                .type(Type.COMMENT)
+                .message(message)
+                .resourceType(ResourceType.POST)
+                .resourceId(postId)
+                .isRead(false)
+                .user(targetUser)
+                .build();
+
+        notificationRepository.save(notification);
+    }
+
+    //댓글에 좋아요 추가 시 알림 생성
+    public void addCommentLikeNotification(Long commentId, Long senderUserId) {
+        Comment comment = commentRepository.findById(commentId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+        User sender = userRepository.findById(senderUserId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 알림 대상은 댓글 작성자
+        User targetUser = comment.getUser();
+        if (targetUser.getId().equals(senderUserId)) return; // 자기 자신에게 알림 X
+
+        // 해당 댓글이 달린 게시글을 찾아서 resource로 전달
+        Post post = comment.getPost();
+
+        String message = "해당 댓글에 좋아요가 달렸습니다.";
+
+        Notification notification = Notification.builder()
+                .type(Type.LIKE)
+                .message(message)
+                .resourceType(ResourceType.POST)
+                .resourceId(post.getId()) // 댓글이 달린 게시글 ID 전달
+                .isRead(false)
+                .user(targetUser)
+                .build();
+
+        notificationRepository.save(notification);
     }
 }

--- a/src/main/java/finance_us/finance_us/domain/post/service/PostLikeService.java
+++ b/src/main/java/finance_us/finance_us/domain/post/service/PostLikeService.java
@@ -1,5 +1,6 @@
 package finance_us.finance_us.domain.post.service;
 
+import finance_us.finance_us.domain.notifications.service.NotificationService;
 import finance_us.finance_us.domain.post.converter.PostLikeConverter;
 import finance_us.finance_us.domain.post.dto.PostLikeResponse;
 import finance_us.finance_us.domain.post.entity.Post;
@@ -19,6 +20,8 @@ public class PostLikeService {
     private final PostRepository postRepository;
     private final UserRepository userRepository;
     private final TokenProvider tokenProvider;
+    //알림 서비스 추가
+    private final NotificationService notificationService;
 
     // 게시글에 좋아요 추가
     public PostLikeResponse.PostLikeResponseDTO likePost(String token, Long postId) {
@@ -46,6 +49,9 @@ public class PostLikeService {
         postLikeRepository.save(postLike);
 
         Long likesCount = postLikeRepository.countLikesByPostId(postId);
+
+        // 알림 추가
+        notificationService.addPostLikeNotification(postId, userId);
 
         return PostLikeConverter.toPostLikeResponseDTO(postLike, likesCount);
     }

--- a/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
+++ b/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
@@ -47,6 +47,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),
 
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT4001", "댓글이 없습니다"),
+
     PAGE_BOUND_ERROR(HttpStatus.BAD_REQUEST, "PAGE4001", "페이징 번호가 적절하지 않습니다."),
 
     CATEGORY_TYPE_ERROR(HttpStatus.BAD_REQUEST,"CATEGORY4001", "카테고리의 타입 문자열이 잘못되었습니다."),


### PR DESCRIPTION
## 💡 관련 이슈
- #87 

## 🎋 요약
- 팔로우 목록 조회 시 전달 정보에 프로필 이미지 추가

## ⚡️ 상세 내용
- 팔로우 목록 조회 시 전달 정보에 프로필 이미지 추가

## 🔑 주요 변경사항
- 스웨거를 통한 테스트 완료
