### PR TITLE
[#70] Feat : 알림 테이블 데이터 관리 로직 구현

### DIFF
--- a/src/main/java/finance_us/finance_us/domain/notifications/service/NotificationService.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/service/NotificationService.java
@@ -107,7 +107,7 @@ public class NotificationService {
 
         // 알림 대상은 가계부 주인
         User targetUser = account.getUser();
-        if (targetUser.getId().equals(senderUserId)) return; // 자기 자신에게 알림 X
+        //if (targetUser.getId().equals(senderUserId)) return; // 자기 자신에게 알림 X
 
         String message = "해당 가계부에 느낌을 표시했습니다.";
 
@@ -132,7 +132,7 @@ public class NotificationService {
 
         // 알림 대상은 게시글 주인
         User targetUser = post.getUser();
-        if (targetUser.getId().equals(senderUserId)) return; // 자기 자신에게 알림 X
+        //if (targetUser.getId().equals(senderUserId)) return; // 자기 자신에게 알림 X
 
         String message = "해당 게시글에 좋아요가 달렸습니다.";
 
@@ -157,7 +157,7 @@ public class NotificationService {
 
         // 알림 대상은 게시글 주인
         User targetUser = post.getUser();
-        if (targetUser.getId().equals(senderUserId)) return; // 자기 자신에게 알림 X
+        //if (targetUser.getId().equals(senderUserId)) return; // 자기 자신에게 알림 X
 
         String message = "해당 게시글에 댓글이 달렸습니다.";
 
@@ -182,7 +182,7 @@ public class NotificationService {
 
         // 알림 대상은 댓글 작성자
         User targetUser = comment.getUser();
-        if (targetUser.getId().equals(senderUserId)) return; // 자기 자신에게 알림 X
+        //if (targetUser.getId().equals(senderUserId)) return; // 자기 자신에게 알림 X
 
         // 해당 댓글이 달린 게시글을 찾아서 resource로 전달
         Post post = comment.getPost();


### PR DESCRIPTION
## 💡 관련 이슈
- #70 

## 🎋 요약
- 알림 테이블 데이터 관리 로직 구현

## ⚡️ 상세 내용
- 가계부에 이모지 표시 시 알림 생성
- 게시글에 좋아요 표시 시 알림 생성
- 게시글 댓글 생성 시 알림 생성
- 댓글 좋아요 표시 시 알림 생성


## 🔑 주요 변경사항
- 스웨거를 통한 테스트 완료
- 대댓글 알림은 대댓글 기능 구현 완료 후 진행 예정
- PM님이 테스트 편의성을 위해 본인이 본인 가계부, 게시글, 댓글에 한 행동에도 알림이 생성되게 해달라고 하셔서, 본인에게도 알림이 가도록 함.