### PR TITLE
Feat/#80 :  사용자 인증 디스코드 연동 기능 구현

### DIFF
--- a/src/main/java/finance_us/finance_us/domain/user/controller/AuthController.java
+++ b/src/main/java/finance_us/finance_us/domain/user/controller/AuthController.java
@@ -120,16 +120,22 @@ public class AuthController {
         return ApiResponse.onFailure("COMMON400", "이메일 인증번호와 다릅니다.", false);
     }
 
-    @PatchMapping("/{userId}")
-    @Operation(summary = "사용자 인증", description = "사용자의 권한을 인증합니다.")
+    @PatchMapping("/user")
+    @Operation(summary = "사용자 인증", description = "사용자의 권한을 인증 요청합니다.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "COMMON200", description = "OK, 성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH003", description = "access 토큰을 주세요!", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH004", description = "acess 토큰 만료", content = @Content(schema = @Schema(implementation = ApiResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "AUTH006", description = "acess 토큰 모양이 이상함", content = @Content(schema = @Schema(implementation = ApiResponse.class)))
     })
-    public ApiResponse<AuthResponseDTO.UserResponseDTO> authUser(@PathVariable Long userId) {
-        return ApiResponse.onSuccess(authService.authUser(userId));
+    public ApiResponse<AuthResponseDTO.UserResponseDTO> authUser(@RequestHeader("Authorization") String token, @RequestBody AuthRequestDTO.userAuthRequestDTO userAuthRequestDTO) {
+        return ApiResponse.onSuccess(authService.authUser(token, userAuthRequestDTO));
+    }
 
+    @PatchMapping("/user/verify")
+    @Operation(summary = "사용자 인증 승인/거절", description = "디스코드에서 요청을 승인 또는 거절합니다.")
+    public ApiResponse<String> verifyUserAuth(@RequestParam Long userId, @RequestParam boolean approved) {
+        authService.verifyUser(userId, approved);
+        return ApiResponse.onSuccess("처리 완료");
     }
 }

--- a/src/main/java/finance_us/finance_us/domain/user/dto/AuthRequestDTO.java
+++ b/src/main/java/finance_us/finance_us/domain/user/dto/AuthRequestDTO.java
@@ -17,7 +17,6 @@ public class AuthRequestDTO {
     public static class LoginRequestDTO{
         private String email;
         private String password;
-
     }
 
     @Getter
@@ -44,5 +43,14 @@ public class AuthRequestDTO {
         private String one_liner;
 
         String imgUrl;
+    }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class userAuthRequestDTO{
+        private String content;
+        private String imgUrl;
     }
 }

--- a/src/main/java/finance_us/finance_us/domain/user/service/AuthService.java
+++ b/src/main/java/finance_us/finance_us/domain/user/service/AuthService.java
@@ -9,6 +9,7 @@ import finance_us.finance_us.global.code.status.ErrorStatus;
 import finance_us.finance_us.global.exception.GeneralException;
 import finance_us.finance_us.security.TokenProvider;
 import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -16,13 +17,12 @@ import org.springframework.stereotype.Service;
 import java.util.Optional;
 
 @Service
+@RequiredArgsConstructor
 public class AuthService {
 
-    @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
-    private TokenProvider tokenProvider;
+    private final UserRepository userRepository;
+    private final TokenProvider tokenProvider;
+    private final DiscordWebhookService discordWebhookService;
 
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
@@ -102,13 +102,24 @@ public class AuthService {
     }
 
     //사용자 인증
-    public AuthResponseDTO.UserResponseDTO authUser(Long userId){
+    public AuthResponseDTO.UserResponseDTO authUser(String token, AuthRequestDTO.userAuthRequestDTO userAuthRequestDTO){
+        Long userId = tokenProvider.extractUserIdFromToken(token);
+
         //사용자 확인
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-        user.setAuthenticated(true);
-        userRepository.save(user);
+
+        discordWebhookService.sendAuthRequest(user, userAuthRequestDTO);
 
         return AuthConverter.toUserResponseDTO(user);
+    }
+
+    //디스코드 승인/거절 요청
+    public void verifyUser(Long userId, boolean isApproved){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        user.setAuthenticated(isApproved); // 승인 or 거절 반영
+        userRepository.save(user);
     }
 }

--- a/src/main/java/finance_us/finance_us/domain/user/service/DiscordWebhookService.java
+++ b/src/main/java/finance_us/finance_us/domain/user/service/DiscordWebhookService.java
@@ -1,0 +1,38 @@
+package finance_us.finance_us.domain.user.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import finance_us.finance_us.domain.user.dto.AuthRequestDTO;
+import finance_us.finance_us.domain.user.entity.User;
+import finance_us.finance_us.global.code.status.ErrorStatus;
+import finance_us.finance_us.global.exception.GeneralException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.*;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+@Service
+public class DiscordWebhookService {
+
+    @Value("${node.server.url}")
+    private String nodeServerUrl;
+    private final RestTemplate restTemplate = new RestTemplate();//http 통신 위해 설정
+
+    public void sendAuthRequest(User user, AuthRequestDTO.userAuthRequestDTO requestDTO) {
+        try {
+            Map<String, Object> payload = new HashMap<>();
+            payload.put("user", Map.of("id", user.getId(), "name", user.getName()));
+            payload.put("requestDTO", Map.of("content", requestDTO.getContent(), "imgUrl", requestDTO.getImgUrl()));
+
+            ResponseEntity<String> response = restTemplate.postForEntity(nodeServerUrl + "/send-auth", payload, String.class);
+
+        } catch (Exception e) {
+            throw new GeneralException(ErrorStatus.DISCORD_ERROR);
+        }
+    }
+}

--- a/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
+++ b/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
@@ -59,9 +59,9 @@ public enum ErrorStatus implements BaseErrorCode {
 
     IMAGE_FAILED(HttpStatus.BAD_REQUEST,"IMAGE4001","이미지 올리는 것을 실패하였습니다."),
 
-    IMAGE_TEXT_FAILD(HttpStatus.BAD_REQUEST, "IMAGETEXT4001", "이미지 텍스트 추출을 실패하였습니다.");
+    IMAGE_TEXT_FAILD(HttpStatus.BAD_REQUEST, "IMAGETEXT4001", "이미지 텍스트 추출을 실패하였습니다."),
 
-
+    DISCORD_ERROR(HttpStatus.BAD_REQUEST,"DISCORD4001","디스코드 메시지 보내기에 실패하였습니다, ");
 
 
 

--- a/src/main/java/finance_us/finance_us/global/config/WebSecurityConfig.java
+++ b/src/main/java/finance_us/finance_us/global/config/WebSecurityConfig.java
@@ -25,6 +25,7 @@ import org.springframework.web.filter.CorsFilter;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
 
 @Configuration
 @EnableMethodSecurity
@@ -93,26 +94,22 @@ public class WebSecurityConfig {
         final long MAX_AGE_SECS = 3600;
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
-        config.setAllowCredentials(true);
-        config.addAllowedHeader("*");
-        config.addAllowedMethod("GET");
-        config.addAllowedMethod("POST");
-        config.addAllowedMethod("PUT");
-        config.addAllowedMethod("DELETE");
-        config.addAllowedMethod("PATCH");
-        config.addAllowedMethod("OPTIONS");
-        config.addAllowedMethod("PATCH");
-        config.setMaxAge(MAX_AGE_SECS);
-        config.addAllowedOrigin("http://localhost:8080");
-        config.addAllowedOrigin("http://localhost:5173");
-        config.addAllowedOrigin("ws://localhost:8080");
-        config.addAllowedOrigin("http://13.209.210.46:8080");
-        config.addAllowedOrigin("ws://13.209.210.46:8080");
+        List<String> allowedOrigins = List.of(
+                "http://localhost:8080",
+                "http://localhost:5173",
+                "ws://localhost:8080",
+                "http://13.209.210.46:8080",
+                "ws://13.209.210.46:8080",
+                "http://localhost:3000",
+                "https://financeus.netlify.app",
+                "http://3.34.46.75"
+        );
 
-        config.addAllowedOrigin("http://localhost:3000");
-        config.addAllowedOrigin("http://localhost:5173");
-        config.addAllowedOrigin("https://financeus.netlify.app");
+        config.setAllowedOrigins(allowedOrigins);
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        config.addAllowedHeader("*");
         source.registerCorsConfiguration("/**", config);
+
         return source;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,3 +53,8 @@ cloud:
 google:
   application:
     credentials: "google-credential.json"
+node:
+  server:
+    url: http://3.34.46.75:3000
+
+


### PR DESCRIPTION
## 💡 관련 이슈
- #80 

## 🎋 요약
- 사용자 인증 기능 구현

## ⚡️ 상세 내용
- 사용자 인증 요청 -> 디스코드 연동 기능 구현 

## 🔑 주요 변경사항
- 사용자가 인증 요청시 디스코드에 연동하여 승인 or 거절 클릭하면 실시간으로 반영될 수 있도록 설정. 배포된 서버에서는 될 지 알 수 없어서 실제 테스트 해봐야 할 것 같습니당 
- cors 너무 길어서 리스트로 수정 
