### PR TITLE
Feat/#70 알림 테이블에 데이터 관리 로직 추가

### DIFF
--- a/src/main/java/finance_us/finance_us/domain/comment/service/CommentService.java
+++ b/src/main/java/finance_us/finance_us/domain/comment/service/CommentService.java
@@ -50,6 +50,7 @@ public class CommentService {
             if (parentComment.isDeleted()) {
                 throw new IllegalStateException("Cannot reply to a deleted comment.");
             }
+
         }
 
         Comment comment = Comment.builder()
@@ -60,7 +61,14 @@ public class CommentService {
                 .build();
 
         // 알림 추가
-        notificationService.addCommentNotification(postId, userId);
+        //부모 댓글이 있는 경우 → 부모 댓글 작성자에게만 알림 전송 (게시글 주인에게는 알림 X)
+        if (parentComment != null) {
+            notificationService.addReplyNotification(parentComment.getId(), userId);
+        }
+        //부모 댓글이 없는 경우 → 게시글 주인에게 댓글 알림 전송
+        else {
+            notificationService.addCommentNotification(postId, userId);
+        }
 
         return commentRepository.save(comment);
     }

--- a/src/main/java/finance_us/finance_us/domain/notifications/controller/NotificationController.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/controller/NotificationController.java
@@ -6,6 +6,7 @@ import finance_us.finance_us.domain.notifications.dto.UnreadNotificationsRespons
 import finance_us.finance_us.domain.notifications.service.NotificationService;
 import finance_us.finance_us.global.ApiResponse;
 import finance_us.finance_us.security.TokenProvider;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -19,6 +20,7 @@ public class NotificationController {
     private final TokenProvider tokenProvider;
 
     @GetMapping
+    @Operation(summary = "읽지 않은 알림 조회 API(스크롤 포함)")
     public ApiResponse<NotificationListResponse> getNotifications(
             @RequestHeader("Authorization") String token,
             @RequestParam(required = false) Long lastNotificationId,
@@ -29,6 +31,7 @@ public class NotificationController {
     }
 
     @GetMapping("/unread")
+    @Operation(summary = "읽지 않은 알림 존재 여부 확인 API")
     public ApiResponse<UnreadNotificationsResponse> hasUnreadNotifications(
             @RequestHeader("Authorization") String token
     ){
@@ -37,6 +40,7 @@ public class NotificationController {
     }
 
     @PatchMapping("/{notificationId}")
+    @Operation(summary = "읽은 알림으로 변경하는 API")
     public ApiResponse<Void> markAsRead(
             @RequestHeader("Authorization") String token,
             @PathVariable Long notificationId

--- a/src/main/java/finance_us/finance_us/domain/notifications/dto/NotificationListResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/dto/NotificationListResponse.java
@@ -1,6 +1,7 @@
 package finance_us.finance_us.domain.notifications.dto;
 
 import finance_us.finance_us.domain.notifications.entity.Notification;
+import finance_us.finance_us.domain.notifications.service.NotificationService;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -12,12 +13,15 @@ public class NotificationListResponse {
     private List<NotificationResponse> notifications; // 알림 목록
     private Long lastNotificationId; // 마지막 알림 ID
 
-    public static NotificationListResponse fromEntities(List<Notification> notifications) {
+    public static NotificationListResponse fromEntities(List<Notification> notifications, NotificationService notificationService) {
         // 마지막 알림 ID를 첫 번째로 추출
         Long lastNotificationId = notifications.isEmpty() ? null : notifications.get(notifications.size() - 1).getId();
 
         List<NotificationResponse> notificationResponses = notifications.stream()
-                .map(NotificationResponse::fromEntity)
+                .map(notification -> {
+                    String resourceTitle = notificationService.getResourceTitle(notification.getResourceType(), notification.getResourceId());
+                    return NotificationResponse.fromEntity(notification, resourceTitle);
+                })
                 .toList();
 
         return new NotificationListResponse(notificationResponses, lastNotificationId);

--- a/src/main/java/finance_us/finance_us/domain/notifications/dto/NotificationResponse.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/dto/NotificationResponse.java
@@ -17,15 +17,19 @@ public class NotificationResponse {
     private ResourceType resourceType;
     private Long resourceId;
     private Boolean isRead;
+    //리소스 제목 필드 추가
+    private String resourceTitle;
 
-    public static NotificationResponse fromEntity(Notification notification) {
+
+    public static NotificationResponse fromEntity(Notification notification, String resourceTitle) {
         return new NotificationResponse(
                 notification.getId(),
                 notification.getType(),
                 notification.getMessage(),
                 notification.getResourceType(),
                 notification.getResourceId(),
-                notification.getIsRead()
+                notification.getIsRead(),
+                resourceTitle
         );
     }
 }

--- a/src/main/java/finance_us/finance_us/domain/notifications/service/NotificationService.java
+++ b/src/main/java/finance_us/finance_us/domain/notifications/service/NotificationService.java
@@ -51,7 +51,21 @@ public class NotificationService {
             notifications = notificationRepository.findByUserIdAndIdANDIsReadFalseLessThanOrderByCreatedAtDesc(userId, lastNotificationId, pageRequest);
         }
 
-        return NotificationListResponse.fromEntities(notifications);
+        return NotificationListResponse.fromEntities(notifications, this);
+    }
+
+    //리소스 제목 조회
+    public String getResourceTitle(ResourceType resourceType, Long resourceId) {
+        if (resourceType == ResourceType.POST) {
+            return postRepository.findById(resourceId)
+                    .map(Post::getTitle)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.ARTICLE_NOT_FOUND));
+        } else if (resourceType == ResourceType.ACCOUNT) {
+            return accountRepository.findById(resourceId)
+                    .map(Account::getTitle)
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.ACCOUNT_NOT_FOUND));
+        }
+        throw new GeneralException(ErrorStatus.RESOURCE_NOT_FOUND);
     }
 
     @Transactional
@@ -184,16 +198,53 @@ public class NotificationService {
         User targetUser = comment.getUser();
         //if (targetUser.getId().equals(senderUserId)) return; // 자기 자신에게 알림 X
 
+
         // 해당 댓글이 달린 게시글을 찾아서 resource로 전달
         Post post = comment.getPost();
 
-        String message = "해당 댓글에 좋아요가 달렸습니다.";
+        //댓글인지, 대댓글인지 확인
+        boolean isReply = comment.getParentComment() != null;
+
+        String message = isReply
+                ? "해당 게시글에 작성한 답글에 좋아요가 달렸습니다."
+                : "해당 게시글에 작성한 댓글에 좋아요가 달렸습니다.";
 
         Notification notification = Notification.builder()
                 .type(Type.LIKE)
                 .message(message)
                 .resourceType(ResourceType.POST)
                 .resourceId(post.getId()) // 댓글이 달린 게시글 ID 전달
+                .isRead(false)
+                .user(targetUser)
+                .build();
+
+        notificationRepository.save(notification);
+    }
+
+    //댓글에 대댓글이 달린 경우
+    public void addReplyNotification(Long parentCommentId, Long senderUserId) {
+        Comment parentComment = commentRepository.findById(parentCommentId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.COMMENT_NOT_FOUND));
+        User sender = userRepository.findById(senderUserId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 알림 대상은 부모 댓글을 작성한 사용자
+        User targetUser = parentComment.getUser();
+
+        // 부모 댓글이 달린 게시글을 찾아서 resource로 전달
+        Post post = parentComment.getPost();
+
+        // 🔹 자기 댓글에 대댓글을 달 경우 알림을 보내지 않음
+        //if (targetUser.getId().equals(senderUserId)) return; 테스트를 위해 자신에게도 알림이 가도록 설정
+
+
+        String message = "해당 게시글에 작성한 댓글에 답글이 달렸습니다.";
+
+        Notification notification = Notification.builder()
+                .type(Type.REPLY) // REPLY 타입의 알림
+                .message(message)
+                .resourceType(ResourceType.POST) // 리소스 타입은 POST
+                .resourceId(post.getId()) // 대댓글이 달린 게시글 ID
                 .isRead(false)
                 .user(targetUser)
                 .build();

--- a/src/main/java/finance_us/finance_us/domain/search/controller/SearchController.java
+++ b/src/main/java/finance_us/finance_us/domain/search/controller/SearchController.java
@@ -6,6 +6,7 @@ import finance_us.finance_us.domain.search.dto.PostSearchResponse;
 import finance_us.finance_us.domain.search.dto.UserSearchResponse;
 import finance_us.finance_us.domain.search.service.SearchService;
 import finance_us.finance_us.global.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
@@ -19,6 +20,7 @@ public class SearchController {
     private final SearchService searchService;
 
     @GetMapping("/posts")
+    @Operation(summary = "게시글 검색 API")
     public ApiResponse<PostSearchResponse> searchPosts(
             @RequestParam PostType boardType,
             @RequestParam(required = false) Long lastId,
@@ -30,6 +32,7 @@ public class SearchController {
     }
 
     @GetMapping("/users")
+    @Operation(summary = "사용자 검색 API")
     public ApiResponse<UserSearchResponse> searchUsers(
             @RequestHeader("Authorization") String token,
             @RequestParam String keyword,

--- a/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
+++ b/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
@@ -58,6 +58,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION4001", "조회할 알림 목록이 없습니다."),
     NOTIFICATION_ALREADY_READ(HttpStatus.BAD_REQUEST, "NOTIFICATION4002", "이미 읽음처리 된 알람입니다."),
+    RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "RESOURCE4001", "존재하지 않는 리소스입니다."),
 
     FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLLOW4001", "팔로우 되지 않은 사용자입니다."),
     ALREADY_FOLLOW(HttpStatus.BAD_REQUEST, "FOLLOW4002", "이미 팔로우 된 사용자입니다."),


### PR DESCRIPTION
## 💡 관련 이슈
- #70 

## 🎋 요약
- 알림 테이블 데이터 관리 로직 추가

## ⚡️ 상세 내용
- 댓글에 답글 작성 시 알림 테이블에 데이터 추가
- 댓글과 답글에 좋아요를 눌렀을 때 메세지 구분
- 알림 조회 시, 리소스 제목도 전달하도록 구현
- 컨트롤러에 API Summary 추가

## 🔑 주요 변경사항
- 스웨거를 통한 테스트 완료
- 테스트 편의를 위해 자신에게도 알림이 가도록 설정
