### PR TITLE
Feat/#94 메인 카테고리 삭제 로직 구현

### DIFF
--- a/src/main/java/finance_us/finance_us/domain/category/controller/CategoryController.java
+++ b/src/main/java/finance_us/finance_us/domain/category/controller/CategoryController.java
@@ -84,7 +84,7 @@ public class CategoryController
     public ApiResponse<?> deleteMainCategory(@RequestHeader("Authorization") String token, Long mainId)
     {
         Long userId = tokenProvider.extractUserIdFromToken(token);
-        categoryService.deleteMainCategory(mainId);
+        categoryService.deleteMainCategory(mainId, userId);
         return ApiResponse.onSuccess("deleted : main_category");
     }
 

--- a/src/main/java/finance_us/finance_us/domain/category/service/CategoryService.java
+++ b/src/main/java/finance_us/finance_us/domain/category/service/CategoryService.java
@@ -103,12 +103,21 @@ public class CategoryService
     }
 
     // 카테고리를 삭제하는 부분
-    public Long deleteMainCategory(Long mainId)
+    public Long deleteMainCategory(Long mainId, Long userId)
     {
+        //메인 카테고리 존재 확인 및 userId 일치 검증
         MainCategory mainCategory = mainCategoryRepository.findById(mainId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.CATEGORY_NOT_FOUND));
 
-        Long userId = mainCategory.getUser().getId();
+        if(!mainCategory.getUser().getId().equals(userId)) {
+            throw new GeneralException(ErrorStatus.CATEGORY_NOT_FOUND);
+        }
+
+        //메인 카테고리와 연관된 서브 카테고리의 존재 여부 확인 (존재한다면 삭제 불가)
+        List<SubCategory> subCategories = subCategoryRepository.findByUserIdAndMainCategoryId(userId, mainId);
+        if (!subCategories.isEmpty()) {
+            throw new GeneralException(ErrorStatus.MAINCATEGORY_HAS_SUBCATEGORY);
+        }
 
         // 🔹 메인 카테고리에 연결된 통계 삭제
         categoryStatisticsService.deleteStatisticsOnCategoryDelete(userId, mainId);

--- a/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
+++ b/src/main/java/finance_us/finance_us/global/code/status/ErrorStatus.java
@@ -55,6 +55,7 @@ public enum ErrorStatus implements BaseErrorCode {
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND,"CATEGORY4002", "카테고리를 찾을 수 없습니다."),
     SUBCATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY4003", "서브카테고리가 존재하지 않습니다. "),
     SUBCATEGORY_HAS_ACCOUNT(HttpStatus.BAD_REQUEST,"CATEGORY4004", "가계부를 가진 서브 카테고리는 삭제할 수 없습니다."),
+    MAINCATEGORY_HAS_SUBCATEGORY(HttpStatus.BAD_REQUEST, "CATEGORY4005", "연관된 서브 카테고리가 존재하는 메인 카테고리는 삭제할 수 없습니다."),
 
     SUB_ASSET_NOT_FOUND(HttpStatus.NOT_FOUND, "ASSET4001", "서브자산이 존재하지 않습니다."),
 


### PR DESCRIPTION
## 💡 관련 이슈
- #94 

## 🎋 요약
- 메인 카테고리 삭제 로직 구현

## ⚡️ 상세 내용
- token에서 추출한 userId를 이용해, 사용자 일치 확인 로직 추가
- 메인 카테고리 삭제 전, 서브 카테고리 존재 확인(존재하면 삭제 불가능)

## 🔑 주요 변경사항
- 스웨거를 통한 테스트 완료
