### PR TITLE
[#120] Fix : 팔로우 목록 조회 버그 수정

### DIFF
--- a/src/main/java/finance_us/finance_us/domain/follows/repository/FollowRepository.java
+++ b/src/main/java/finance_us/finance_us/domain/follows/repository/FollowRepository.java
@@ -18,7 +18,7 @@ public interface FollowRepository extends JpaRepository<Follow, Long> {
 
     boolean existsByUserIdAndFollowingId(Long userId, Long followingId);
 
-    @Query("SELECT f FROM Follow f WHERE f.user.Id = :userId AND f.followingId > :lastFollowingId ORDER BY f.createdAt ASC")
+    @Query("SELECT f FROM Follow f WHERE f.user.Id = :userId AND f.followingId > :lastFollowingId ORDER BY f.followingId ASC")
     List<Follow> findByUserIdAndIdGreaterThan(
             @Param("userId") Long userId,
             @Param("lastFollowingId") Long lastFollowingId,

--- a/src/main/java/finance_us/finance_us/domain/follows/service/FollowService.java
+++ b/src/main/java/finance_us/finance_us/domain/follows/service/FollowService.java
@@ -13,6 +13,7 @@ import finance_us.finance_us.security.TokenProvider;
 import lombok.AllArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -62,7 +63,7 @@ public class FollowService {
         Long userId = tokenProvider.extractUserIdFromToken(token);
         lastFollowingId = (lastFollowingId == null) ? 0 : lastFollowingId;
 
-        PageRequest pageRequest = PageRequest.of(0, size);
+        PageRequest pageRequest = PageRequest.of(0, size, Sort.by(Sort.Direction.ASC, "followingId"));
 
         List<Follow> follows = followRepository.findByUserIdAndIdGreaterThan(userId, lastFollowingId, pageRequest);
 


### PR DESCRIPTION
## 💡 관련 이슈
- #120 

## 🎋 요약
- 팔로우 목록 조회 버그 수정

## ⚡️ 상세 내용
- 팔로우 목록 조회 시 페이징에서 이전에 조회된 사용자가 나오지 않도록 수정

## 🔑 주요 변경사항
- 스웨거를 통한 테스트 완료
